### PR TITLE
Retaining cgroup-driver as systemd to make it compatible with kubelet

### DIFF
--- a/magnum/drivers/common/templates/fragments/configure_docker_storage_driver_atomic.sh
+++ b/magnum/drivers/common/templates/fragments/configure_docker_storage_driver_atomic.sh
@@ -70,6 +70,7 @@ try:
 except IOError:
     opts = {}
 
+opts["exec-opts"] = ["native.cgroupdriver=systemd"]
 opts["storage-driver"] = "$DOCKER_STORAGE_DRIVER"
 
 with open("/etc/docker/daemon.json", "w") as f:
@@ -138,6 +139,7 @@ try:
 except IOError:
     opts = {}
 
+opts["exec-opts"] = ["native.cgroupdriver=systemd"]
 opts["storage-driver"] = "devicemapper"
 opts["storage-opts"] = [
     "dm.thinpooldev=/dev/mapper/docker-thinpool",


### PR DESCRIPTION
Change-Id: I99bb3f4d746763c6610ffbedae3a333ae5150b17