### PR TITLE
Support disabling floating IPs in swarm mode clusters

### DIFF
--- a/magnum/drivers/common/templates/environments/disable_floating_ip.yaml
+++ b/magnum/drivers/common/templates/environments/disable_floating_ip.yaml
@@ -14,3 +14,9 @@ resource_registry:
 
   # dcosslave.yaml
   "Magnum::Optional::DcosSlave::Neutron::FloatingIP": "OS::Heat::None"
+
+  # swarmmaster.yaml
+  "Magnum::Optional::SwarmMaster::Neutron::FloatingIP": "OS::Heat::None"
+
+  # swarmnode.yaml
+  "Magnum::Optional::SwarmNode::Neutron::FloatingIP": "OS::Heat::None"

--- a/magnum/drivers/common/templates/environments/enable_floating_ip.yaml
+++ b/magnum/drivers/common/templates/environments/enable_floating_ip.yaml
@@ -14,3 +14,9 @@ resource_registry:
 
   # dcosslave.yaml
   "Magnum::Optional::DcosSlave::Neutron::FloatingIP": "OS::Neutron::FloatingIP"
+
+  # swarmmaster.yaml
+  "Magnum::Optional::SwarmMaster::Neutron::FloatingIP": "OS::Neutron::FloatingIP"
+
+  # swarmnode.yaml
+  "Magnum::Optional::SwarmNode::Neutron::FloatingIP": "OS::Neutron::FloatingIP"

--- a/magnum/drivers/common/templates/swarm/fragments/make-cert.py
+++ b/magnum/drivers/common/templates/swarm/fragments/make-cert.py
@@ -71,13 +71,19 @@ def _get_public_ip():
 
 
 def _build_subject_alt_names(config):
-    subject_alt_names = [
-        'IP:%s' % _get_public_ip(),
-        'IP:%s' % config['API_IP_ADDRESS'],
-        'IP:%s' % config['SWARM_NODE_IP'],
-        'IP:%s' % config['SWARM_API_IP'],
-        'IP:127.0.0.1'
-    ]
+    ips = {
+        config['SWARM_NODE_IP'],
+        config['SWARM_API_IP'],
+	'127.0.0.1',
+    }
+    # NOTE(mgoddard): If floating IP is disabled, these can be empty.
+    public_ip = _get_public_ip()
+    if public_ip:
+        ips.add(public_ip)
+    api_ip = config['API_IP_ADDRESS']
+    if api_ip:
+        ips.add(api_ip)
+    subject_alt_names = ['IP:%s' % ip for ip in ips]
     return ','.join(subject_alt_names)
 
 
@@ -95,9 +101,10 @@ def write_ca_cert(config, verify_ca):
 
 
 def write_server_key():
-    subprocess.call(['openssl', 'genrsa',
-                     '-out', SERVER_KEY_PATH,
-                     '4096'])
+    subprocess.check_call(
+        ['openssl', 'genrsa',
+         '-out', SERVER_KEY_PATH,
+         '4096'])
 
 
 def _write_csr_config(config):
@@ -110,13 +117,14 @@ def _write_csr_config(config):
 
 def create_server_csr(config):
     _write_csr_config(config)
-    subprocess.call(['openssl', 'req', '-new',
-                     '-days', '1000',
-                     '-key', SERVER_KEY_PATH,
-                     '-out', SERVER_CSR_PATH,
-                     '-reqexts', 'req_ext',
-                     '-extensions', 'req_ext',
-                     '-config', SERVER_CONF_PATH])
+    subprocess.check_call(
+        ['openssl', 'req', '-new',
+         '-days', '1000',
+         '-key', SERVER_KEY_PATH,
+         '-out', SERVER_CSR_PATH,
+         '-reqexts', 'req_ext',
+         '-extensions', 'req_ext',
+         '-config', SERVER_CONF_PATH])
 
     with open(SERVER_CSR_PATH, 'r') as fp:
         return {'cluster_uuid': config['CLUSTER_UUID'], 'csr': fp.read()}

--- a/magnum/drivers/heat/swarm_mode_template_def.py
+++ b/magnum/drivers/heat/swarm_mode_template_def.py
@@ -128,5 +128,6 @@ class SwarmModeTemplateDefinition(template_def.BaseTemplateDefinition):
         template_def.add_priv_net_env_file(env_files, cluster_template)
         template_def.add_volume_env_file(env_files, cluster)
         template_def.add_lb_env_file(env_files, cluster_template)
+        template_def.add_fip_env_file(env_files, cluster_template)
 
         return env_files

--- a/magnum/drivers/swarm_fedora_atomic_v2/templates/swarmcluster.yaml
+++ b/magnum/drivers/swarm_fedora_atomic_v2/templates/swarmcluster.yaml
@@ -276,6 +276,18 @@ resources:
 
   ######################################################################
   #
+  # resources that expose the IPs of either floating ip or a given
+  # fixed ip depending on whether FloatingIP is enabled for the cluster.
+  #
+
+  api_address_floating_switch:
+    type: Magnum::FloatingIPAddressSwitcher
+    properties:
+      public_ip: {get_attr: [api_address_lb_switch, public_ip]}
+      private_ip: {get_attr: [api_address_lb_switch, private_ip]}
+
+  ######################################################################
+  #
   # resources that expose the server group for all nodes include master
   # and minions.
   #
@@ -434,7 +446,7 @@ outputs:
       str_replace:
         template: api_ip_address
         params:
-          api_ip_address: {get_attr: [api_address_lb_switch, public_ip]}
+          api_ip_address: {get_attr: [api_address_floating_switch, ip_address]}
     description: >
       This is the API endpoint of the Swarm masters. Use this to access
       the Swarm API server from outside the cluster.

--- a/magnum/drivers/swarm_fedora_atomic_v2/templates/swarmmaster.yaml
+++ b/magnum/drivers/swarm_fedora_atomic_v2/templates/swarmmaster.yaml
@@ -346,7 +346,7 @@ resources:
             get_param: fixed_subnet_id
 
   swarm_master_floating:
-    type: "OS::Neutron::FloatingIP"
+    type: "Magnum::Optional::SwarmMaster::Neutron::FloatingIP"
     properties:
       floating_network:
         get_param: external_network

--- a/magnum/drivers/swarm_fedora_atomic_v2/templates/swarmnode.yaml
+++ b/magnum/drivers/swarm_fedora_atomic_v2/templates/swarmnode.yaml
@@ -318,7 +318,7 @@ resources:
             get_param: fixed_subnet_id
 
   swarm_node_floating:
-    type: "OS::Neutron::FloatingIP"
+    type: "Magnum::Optional::SwarmNode::Neutron::FloatingIP"
     properties:
       floating_network:
         get_param: external_network


### PR DESCRIPTION
We use the same technique that is used for kubernetes clusters, with a
custom heat resource that provides either a floating IP, or
OS::Heat::None when disabled.

Change-Id: I3b5877bcd89fc2436776f49e479ffadf72c00ea3