### PR TITLE
rebase stackhpc/rocky patches on stable/stein

### DIFF
--- a/magnum/drivers/common/templates/fragments/configure_docker_storage_driver_atomic.sh
+++ b/magnum/drivers/common/templates/fragments/configure_docker_storage_driver_atomic.sh
@@ -47,5 +47,5 @@ configure_devicemapper () {
         echo "DATA_SIZE=95%FREE" >> /etc/sysconfig/docker-storage-setup
     fi
 
-    docker-storage-setup
+    container-storage-setup
 }

--- a/magnum/drivers/common/templates/swarm/fragments/add-docker-daemon-options.sh
+++ b/magnum/drivers/common/templates/swarm/fragments/add-docker-daemon-options.sh
@@ -2,12 +2,11 @@
 
 . /etc/sysconfig/heat-params
 
-opts="-H fd:// -H tcp://0.0.0.0:2375 "
-
-if [ "$TLS_DISABLED" = 'False' ]; then
-    opts=$opts"--tlsverify --tlscacert=/etc/docker/ca.crt "
-    opts=$opts"--tlskey=/etc/docker/server.key "
-    opts=$opts"--tlscert=/etc/docker/server.crt "
+if [[ -f /etc/sysconfig/docker ]]; then
+    SET_LOG_DRIVER=False
+else
+    SET_LOG_DRIVER=True
+    LOG_DRIVER=journald
 fi
 
 sed -i '/^OPTIONS=/ s#\(OPTIONS='"'"'\)#\1'"$opts"'#' /etc/sysconfig/docker
@@ -16,3 +15,36 @@ sed -i '/^OPTIONS=/ s#\(OPTIONS='"'"'\)#\1'"$opts"'#' /etc/sysconfig/docker
 # If its specified the swarm init will fail so we remove it here.
 # See: https://docs.docker.com/config/containers/live-restore
 sed -i 's/\ --live-restore//g' /etc/sysconfig/docker
+
+# The Docker CE distribution does not provide sufficient SELinux support.
+# With SELinux enabled, non-privilged containers are unable to (for
+# example) bind to privileged ports as root in the container.
+SET_SELINUX_ENABLED=False
+
+cat | python << EOF
+import json
+
+try:
+    with open("/etc/docker/daemon.json") as f:
+        opts = json.load(f)
+except IOError:
+    opts = {}
+
+opts["hosts"] = ["fd://"]
+if "${SET_LOG_DRIVER}" == "True":
+    opts["log-driver"] = "${LOG_DRIVER}"
+if "${SET_SELINUX_ENABLED}" == "True":
+    opts["selinux-enabled"] = True
+if "${SWARM_MODE}" == "True":
+    opts["hosts"].append("tcp://0.0.0.0:2376")
+else:
+    opts["hosts"].append("tcp://0.0.0.0:2375")
+if "${TLS_DISABLED}" == "False":
+    opts["tlsverify"] = True
+    opts["tlscacert"] = "/etc/docker/ca.crt"
+    opts["tlskey"] = "/etc/docker/server.key"
+    opts["tlscert"] = "/etc/docker/server.crt"
+
+with open("/etc/docker/daemon.json", "w") as f:
+    json.dump(opts, f, sort_keys=True, indent=4)
+EOF

--- a/magnum/drivers/common/templates/swarm/fragments/add-docker-daemon-options.sh
+++ b/magnum/drivers/common/templates/swarm/fragments/add-docker-daemon-options.sh
@@ -31,14 +31,11 @@ except IOError:
     opts = {}
 
 opts["hosts"] = ["fd://"]
+opts["hosts"].append("tcp://0.0.0.0:2375")
 if "${SET_LOG_DRIVER}" == "True":
     opts["log-driver"] = "${LOG_DRIVER}"
 if "${SET_SELINUX_ENABLED}" == "True":
     opts["selinux-enabled"] = True
-if "${SWARM_MODE}" == "True":
-    opts["hosts"].append("tcp://0.0.0.0:2376")
-else:
-    opts["hosts"].append("tcp://0.0.0.0:2375")
 if "${TLS_DISABLED}" == "False":
     opts["tlsverify"] = True
     opts["tlscacert"] = "/etc/docker/ca.crt"


### PR DESCRIPTION
Looks like we were carrying the following patches:

pick 373cc3bd Configure docker daemon via platform-agnostic daemon.json
pick c18c4eb6 Change docker-storage-setup to container-storage-setup and remove swarm mode specific host

These still necessary?