### PR TITLE
WIP: Fix proportional autoscaler image

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
@@ -6,7 +6,7 @@ printf "Starting to run ${step}\n"
 . /etc/sysconfig/heat-params
 
 _dns_prefix=${CONTAINER_INFRA_PREFIX:-docker.io/coredns/}
-_autoscaler_prefix=${CONTAINER_INFRA_PREFIX:-docker.io/googlecontainer/}
+_autoscaler_prefix=${CONTAINER_INFRA_PREFIX:-gcr.io/google_containers/}
 
 CORE_DNS=/srv/magnum/kubernetes/manifests/kube-coredns.yaml
 [ -f ${CORE_DNS} ] || {


### PR DESCRIPTION
The proportional autoscaler was not taken from
the real gcr.io/google_containers but but from
docker.io/googlecontainer.

story: 2003993
task: 30492

Change-Id: I2b6fa6f6c839d86b935feb9e1fa9f044d1835b34
Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>
(cherry picked from commit c0e51198a3116d2ddc81edba220b56ebea528fd8)
(cherry picked from commit e9f4a126b354edd349550b7d82724c5028c4c554)