### PR TITLE
WIP: Support SR-IOV

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -485,6 +485,11 @@ the table are linked to more details elsewhere in the user guide.
 +---------------------------------------+--------------------+---------------+
 | `fixed_subnet_cidr`_                  | see below          | ""            |
 +---------------------------------------+--------------------+---------------+
+| `vnic_type`_                          | see below          | "normal"      |
++---------------------------------------+--------------------+---------------+
+| `master_vnic_type`_                   | see below          | ""            |
++---------------------------------------+--------------------+---------------+
+
 
 .. _cluster:
 
@@ -1636,6 +1641,16 @@ _`fixed_subnet_cidr`
   CIDR of the fixed subnet created by Magnum when a user has not
   specified an existing fixed_subnet during cluster creation.
   Ussuri default: 10.0.0.0/24
+
+_`vnic_type`
+  The vnic type to use for ports attached to nodes. This is useful if the user
+  wants to attach SR-IOV nics to instances which requires vnic_type=direct.
+  Default: "normal"
+
+_`master_vnic_type`
+  The vnic type to use for ports attached to master nodes. Defaults to the
+  value of `vnic_type` when undefined.
+  Default: ""
 
 External load balancer for services
 -----------------------------------

--- a/magnum/drivers/heat/k8s_fedora_template_def.py
+++ b/magnum/drivers/heat/k8s_fedora_template_def.py
@@ -118,6 +118,7 @@ class K8sFedoraTemplateDefinition(k8s_template_def.K8sTemplateDefinition):
                       'min_node_count', 'max_node_count', 'npd_enabled',
                       'ostree_remote', 'ostree_commit',
                       'use_podman', 'kube_image_digest',
+                      'vnic_type', 'master_vnic_type',
                       'metrics_scraper_tag']
 
         labels = self._get_relevant_labels(cluster, kwargs)

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -26,6 +26,12 @@ conditions:
       - get_param: worker_role
       - ""
 
+  use_master_vnic_type:
+    not:
+      equals:
+      - get_param: master_vnic_type
+      - ""
+
   master_only:
     or:
     - create_cluster_resources
@@ -920,6 +926,18 @@ parameters:
       specific configs
     default: ""
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+    default: "normal"
+
+  master_vnic_type:
+    type: string
+    description: >
+      vnic type for ports attached to master nodes which defaults to
+      vnic_type when undefined.
+    default: ""
+
 resources:
 
   ######################################################################
@@ -1158,6 +1176,11 @@ resources:
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
           traefik_ingress_controller_tag: {get_param: traefik_ingress_controller_tag}
+          vnic_type:
+            if:
+              - use_master_vnic_type
+              - get_param: master_vnic_type
+              - get_param: vnic_type
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           fixed_network: {get_attr: [network, fixed_network]}
@@ -1387,6 +1410,7 @@ resources:
           registry_chunksize: {get_param: registry_chunksize}
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
+          vnic_type: {get_param: vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           auth_url: {get_param: auth_url}

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
@@ -104,6 +104,10 @@ parameters:
       the docker cgroup driver.
     default: "cgroupfs"
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -922,6 +926,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_master_floating:
     type: Magnum::Optional::KubeMaster::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
@@ -164,6 +164,10 @@ parameters:
     type: string
     description: ID of the security group for kubernetes minion.
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -545,6 +549,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_minion_floating:
     type: Magnum::Optional::KubeMinion::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -26,6 +26,12 @@ conditions:
       - get_param: worker_role
       - ""
 
+  use_master_vnic_type:
+    not:
+      equals:
+      - get_param: master_vnic_type
+      - ""
+
   master_only:
     or:
     - create_cluster_resources
@@ -943,6 +949,18 @@ parameters:
     description: The allowed CIDR list for master load balancer
     default: []
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+    default: "normal"
+
+  master_vnic_type:
+    type: string
+    description: >
+      vnic type for ports attached to master nodes which defaults to
+      vnic_type when undefined.
+    default: ""
+
 resources:
 
   ######################################################################
@@ -1193,6 +1211,11 @@ resources:
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
           traefik_ingress_controller_tag: {get_param: traefik_ingress_controller_tag}
+          vnic_type:
+            if:
+              - use_master_vnic_type
+              - get_param: master_vnic_type
+              - get_param: vnic_type
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           fixed_network: {get_attr: [network, fixed_network]}
@@ -1424,6 +1447,7 @@ resources:
           registry_chunksize: {get_param: registry_chunksize}
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
+          vnic_type: {get_param: vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           auth_url: {get_param: auth_url}

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -108,6 +108,10 @@ parameters:
       the docker cgroup driver.
     default: "cgroupfs"
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -932,6 +936,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_master_floating:
     type: Magnum::Optional::KubeMaster::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -168,6 +168,10 @@ parameters:
     type: string
     description: ID of the security group for kubernetes minion.
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -545,6 +549,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_minion_floating:
     type: Magnum::Optional::KubeMinion::Neutron::FloatingIP

--- a/magnum/tests/unit/drivers/test_template_definition.py
+++ b/magnum/tests/unit/drivers/test_template_definition.py
@@ -645,6 +645,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
         metrics_scraper_tag = mock_cluster.labels.get('metrics_scraper_tag')
         master_lb_allowed_cidrs = mock_cluster.labels.get(
             'master_lb_allowed_cidrs')
+        vnic_type = mock_cluster.labels.get('vnic_type')
+        master_vnic_type = mock_cluster.labels.get('master_vnic_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -761,6 +763,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'metrics_scraper_tag': metrics_scraper_tag,
             'master_lb_allowed_cidrs': master_lb_allowed_cidrs,
             'fixed_subnet_cidr': '20.200.0.0/16',
+            'vnic_type': vnic_type,
+            'master_vnic_type': master_vnic_type,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,
@@ -1174,9 +1178,10 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'containerd_tarball_sha256')
         kube_image_digest = mock_cluster.labels.get('kube_image_digest')
         metrics_scraper_tag = mock_cluster.labels.get('metrics_scraper_tag')
-
         master_lb_allowed_cidrs = mock_cluster.labels.get(
             'master_lb_allowed_cidrs')
+        vnic_type = mock_cluster.labels.get('vnic_type')
+        master_vnic_type = mock_cluster.labels.get('master_vnic_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -1295,6 +1300,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'metrics_scraper_tag': metrics_scraper_tag,
             'master_lb_allowed_cidrs': master_lb_allowed_cidrs,
             'fixed_subnet_cidr': '20.200.0.0/16',
+            'vnic_type': vnic_type,
+            'master_vnic_type': master_vnic_type,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,

--- a/releasenotes/notes/vnic-type-ab55eee505bee5e5.yaml
+++ b/releasenotes/notes/vnic-type-ab55eee505bee5e5.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support for `vnic_type` label to support modes other than `normal`
+    (default mode) for supporting SR-IOV nics. A separate `master_vnic_type`
+    can be defined for master nodes which defaults to the value of `vnic_type`
+    when undefined.


### PR DESCRIPTION
Support vnic_type and master_vnic_type labels which allow Magnum
clusters to support instances with SR-IOV ports which requires
vnic_type=direct since default vnic_type=normal. When undefined,
master_vnic_type defaults to the value of vnic_type.

Story: 2008078
Task: 40770

Change-Id: Ia309fee86bcedf1a5d86ed6997154c8dbc99f19e
(cherry picked from commit 3614d52cefa1dbbbc76348c3e28e018cb4b07617)

Conflicts:
	magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml