### PR TITLE
Fix cluster deletion when load balancers don't exist

### DIFF
--- a/magnum/common/octavia.py
+++ b/magnum/common/octavia.py
@@ -111,6 +111,8 @@ def delete_loadbalancers(context, cluster):
             filters={"type": lb_resource_type})
         for lb_res in lb_resources:
             lb_id = lb_res.physical_resource_id
+            if not lb_id:
+                continue
             try:
                 lb = octavia_client.load_balancer_show(lb_id)
                 lbs.append(lb)

--- a/releasenotes/notes/story-2008548-65a571ad15451937.yaml
+++ b/releasenotes/notes/story-2008548-65a571ad15451937.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue with cluster deletion if load balancers do not exist. See
+    `story 2008548 <https://storyboard.openstack.org/#!/story/2008548>` for
+    details.


### PR DESCRIPTION
During cluster deletion, magnum tries to delete the cluster's load
balancers in advance of deleting the heat stack. If these load balancers
do not exist for some reason, the cluster deletion will fail with an
error such as the following:

    Failed to pre-delete resources for cluster
    748b628a-2cd8-456f-8aee-c93804b2099b, error: list indices must be
    integers or slices, not str.

This happens because the heat stack has the physical_resource_id set to
None for the load balancer, which causes the load_balancer_show method
of octavia client to GET all load balancers, rather than just one. The
returned data is a list, rather than a dict, leading to the error above.

This change fixes the issue by checking if physical_resource_id is set
to None, and skipping the load balancer deletion if so.

Change-Id: I8f4ca497a01ad04db6cb6c4bc81caed0d714b5a6
Story: 2008548
Task: 41669
(cherry picked from commit 8018bf9124a17bc386ee06cc0a4ea9c36c3bbb55)