### PR TITLE
Support Kubernetes 1.19 and 1.20

### DIFF
--- a/api-ref/source/clusters.inc
+++ b/api-ref/source/clusters.inc
@@ -45,6 +45,7 @@ Request
   - fixed_subnet: fixed_subnet
   - fixed_network: fixed_network
   - floating_ip_enabled: floating_ip_enabled_cluster
+  - master_lb_enabled: master_lb_enabled_cluster
 
 .. note::
 
@@ -163,6 +164,8 @@ Response
   - node_addresses: node_addresses
   - status_reason: status_reason
   - create_timeout: create_timeout
+  - floating_ip_enabled: floating_ip_enabled_cluster
+  - master_lb_enabled: master_lb_enabled_cluster
   - name: name
 
 Response Example

--- a/api-ref/source/clusters.inc
+++ b/api-ref/source/clusters.inc
@@ -106,6 +106,7 @@ Response
   - cluster_template_id: clustertemplate_id
   - node_count: node_count
   - create_timeout: create_timeout
+  - project_id: project_id
   - name: name
 
 Response Example
@@ -166,6 +167,7 @@ Response
   - create_timeout: create_timeout
   - floating_ip_enabled: floating_ip_enabled_cluster
   - master_lb_enabled: master_lb_enabled_cluster
+  - project_id: project_id
   - name: name
 
 Response Example

--- a/api-ref/source/clustertemplates.inc
+++ b/api-ref/source/clustertemplates.inc
@@ -48,6 +48,7 @@ Request
   - volume_driver: volume_driver
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
+  - project_id: project_id
   - name: name
   - network_driver: network_driver
   - fixed_network: fixed_network
@@ -93,6 +94,7 @@ Response
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
   - apiserver_port: apiserver_port
+  - project_id: project_id
   - name: name
   - created_at: created_at
   - network_driver: network_driver
@@ -158,6 +160,7 @@ Response
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
   - apiserver_port: apiserver_port
+  - project_id: project_id
   - name: name
   - created_at: created_at
   - network_driver: network_driver
@@ -231,6 +234,7 @@ Response
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
   - apiserver_port: apiserver_port
+  - project_id: project_id
   - name: name
   - created_at: created_at
   - network_driver: network_driver

--- a/api-ref/source/parameters.yaml
+++ b/api-ref/source/parameters.yaml
@@ -403,6 +403,18 @@ master_lb_enabled:
   in: body
   required: true
   type: boolean
+master_lb_enabled_cluster:
+  description: |
+    Since multiple masters may exist in a bay/cluster, a Neutron load balancer
+    is created to provide the API endpoint for the bay/cluster and to direct
+    requests to the masters. In some cases, such as when the LBaaS service is
+    not available, this option can be set to ``false`` to create a bay/cluster
+    without the load balancer. In this case, one of the masters will serve as
+    the API endpoint. The default is ``true``, i.e. to create the load
+    balancer for the bay.
+  in: body
+  required: false
+  type: boolean
 max_batch_size:
   description: |
     The max batch size each time when doing upgrade, default value is 1

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -485,6 +485,11 @@ the table are linked to more details elsewhere in the user guide.
 +---------------------------------------+--------------------+---------------+
 | `fixed_subnet_cidr`_                  | see below          | ""            |
 +---------------------------------------+--------------------+---------------+
+| `vnic_type`_                          | see below          | "normal"      |
++---------------------------------------+--------------------+---------------+
+| `master_vnic_type`_                   | see below          | "normal       |
++---------------------------------------+--------------------+---------------+
+
 
 .. _cluster:
 
@@ -1640,6 +1645,15 @@ _`fixed_subnet_cidr`
   CIDR of the fixed subnet created by Magnum when a user has not
   specified an existing fixed_subnet during cluster creation.
   Ussuri default: 10.0.0.0/24
+
+_`vnic_type`
+  The vnic type to use for ports attached to worker nodes. This allows
+  the user to, for example, attach SR-IOV ports to instances.
+  Default: normal
+
+_`master_vnic_type`
+  The vnic type to use for ports attached to worker nodes.
+  Default: normal
 
 External load balancer for services
 -----------------------------------

--- a/doc/source/user/k8s-keystone-authN-authZ.rst
+++ b/doc/source/user/k8s-keystone-authN-authZ.rst
@@ -44,29 +44,30 @@ can configure their cluster's role policies with those roles.
 Setup configmap for authorization policies
 ------------------------------------------
 
-Given the k8s Keystone auth has been enable by default, user can get the
-authentication support by default without doing anything. However, user can't
-do anything actually before setup a default authorization policies.
+While the `k8s-keystone-auth` service is enabled in clusters by default, users
+will need specify their own authorization policy to start making use of this
+feature.
 
-The authorization policy can be specified using an existing configmap name in
-the cluster, by doing this, the policy could be changed dynamically without
-the k8s-keystone-auth service restart.
+The user can specify their own authorization policy by either:
 
-Or the policy can be read from a default policy file. In devstack, the policy
-file will be created automatically.
+- Updating the placeholder `k8s-keystone-auth-policy` configmap, created
+  by default in the `kube-system` namespace. This does not require restarting
+  the `k8s-keystone-auth` service.
+- Reading the policy from a default policy file. In devstack the policy file is
+  created automatically.
 
-Currently, k8s-keystone-auth service supports four types of policies:
+Currently, the `k8s-keystone-auth` service supports four types of policies:
 
 - user. The Keystone user ID or name.
-- roject. The Keystone project ID or name.
+- project. The Keystone project ID or name.
 - role. The user role defined in Keystone.
 - group. The group is not a Keystone concept actually, it’s supported for
   backward compatibility, you can use group as project ID.
 
-For example, in the following configmap, we only allow the users in
-project demo with k8s-viewer role in OpenStack to query the pod information
-from all the namespaces. So we need to update the configmap
-`k8s-keystone-auth-policy` which has been created in kube-system namespace.
+For example, if we wish to configure a policy to only allow the users in
+project `demo` with `k8s-viewer` role in OpenStack to query the pod information
+from all the namespaces, then we can update the default
+`k8s-keystone-auth-policy` configmap as follows.
 
 .. code-block:: bash
 
@@ -100,12 +101,18 @@ from all the namespaces. So we need to update the configmap
         ]
     EOF
 
-Please note that the default configmap name is `k8s-keystone-auth-policy`, user
-can change it, but they have to change the config of the k8s keystone auth
-service configuration as well and restart the service.
+More on keystone authorization policies can be found in the
+kubernetes/cloud-provider-openstack documentation for
+`Using the Keystone Webhook Authenticator and Authorizer
+<https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-keystone-webhook-authenticator-and-authorizer.md#prepare-the-authorization-policy-optional>`_
 
-Now user need to get a token from Keystone to have a kubeconfig for kubectl,
-user can also get the config with Magnum python client.
+Note: If the user wishes to use an alternate name for the
+`k8s-keystone-auth-policy` configmap they will need to update the value of the
+`--policy-configmap-name` parameter passed to the `k8s-keystone-auth` service
+and then restart the service.
+
+Next the user needs to get a token from Keystone to have a kubeconfig for
+kubectl. The user can also get the config with Magnum python client.
 
 Here is a sample of the kubeconfig:
 
@@ -141,5 +148,49 @@ Here is a sample of the kubeconfig:
                 echo '{ "apiVersion": "client.authentication.k8s.io/v1alpha1", "kind": "ExecCredential", "status": { "token": "'"${OS_TOKEN}"'"}}'
             fi
 
-Now after export the Keystone token to OS_TOKEN, user should be able to list
-pods with kubectl.
+After exporting the Keystone token to the ``OS_TOKEN`` environment variable,
+the user should be able to list pods with `kubectl`.
+
+Setup configmap for role synchronization policies
+-------------------------------------------------
+
+To start taking advantage of role synchronization between kubernetes and openstack
+users need to specify an `authentication synchronization policy
+<https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-auth-data-synchronization.md#example-of-sync-config-file>`_
+
+Users can specify their own policy by either:
+
+- Updating the placeholder `keystone-sync-policy` configmap, created by
+  default in the `kube-system` namespace. This does *not* require restarting
+  `k8s-keystone-auth`
+- Reading the policy from a local config file. This requires restarting the
+  `k8s-keystone-auth` service.
+
+For example, to set a policy which assigns the `project-1` group in
+kubernetes to users who have been assigned the `member` role in Keystone the
+user can update the default `keystone-sync-policy` configmap as follows.
+
+.. code-block:: bash
+
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+    name: keystone-sync-policy
+    namespace: kube-system
+    data:
+    syncConfig: |
+        role-mappings:
+          - keystone-role: member
+            groups: ["project-1"]
+    EOF
+
+If users wish to use an alternative name for the keystone-sync-policy
+configmap they will need to update the value of the ``--sync-configmap-name``
+parameter passed to the `k8s-keystone-auth` service and then restart service.
+
+For more examples and information on configuring and using authorization
+synchronization policies please refer to the
+kubernetes/cloud-provider-openstack documentation for `Authentication
+synchronization between Keystone and Kubernetes
+<https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-auth-data-synchronization.md>`_

--- a/doc/source/user/k8s-keystone-authN-authZ.rst
+++ b/doc/source/user/k8s-keystone-authN-authZ.rst
@@ -176,10 +176,10 @@ user can update the default `keystone-sync-policy` configmap as follows.
     apiVersion: v1
     kind: ConfigMap
     metadata:
-    name: keystone-sync-policy
-    namespace: kube-system
+      name: keystone-sync-policy
+      namespace: kube-system
     data:
-    syncConfig: |
+      syncConfig: |
         role-mappings:
           - keystone-role: member
             groups: ["project-1"]

--- a/magnum/api/attr_validator.py
+++ b/magnum/api/attr_validator.py
@@ -209,7 +209,7 @@ def validate_os_resources(context, cluster_template, cluster=None):
 
 def validate_master_count(cluster, cluster_template):
     if cluster['master_count'] > 1 and \
-            not cluster_template['master_lb_enabled']:
+            not cluster['master_lb_enabled']:
         raise exception.InvalidParameterValue(_(
             "master_count must be 1 when master_lb_enabled is False"))
 

--- a/magnum/api/controllers/v1/cluster.py
+++ b/magnum/api/controllers/v1/cluster.py
@@ -228,6 +228,7 @@ class Cluster(base.APIBase):
                                          'labels', 'node_count', 'status',
                                          'master_flavor_id', 'flavor_id',
                                          'create_timeout', 'master_count',
+                                         'project_id',
                                          'stack_id', 'health_status'])
         else:
             overridden, added, skipped = api_utils.get_labels_diff(
@@ -255,6 +256,7 @@ class Cluster(base.APIBase):
         temp_id = '4a96ac4b-2447-43f1-8ca6-9fd6f36d146d'
         sample = cls(uuid='27e3153e-d5bf-4b7e-b517-fb518e17f34c',
                      name='example',
+                     project_id='37e3153e-d5bf-4b7e-b517-fb518e17f34d',
                      cluster_template_id=temp_id,
                      keypair=None,
                      node_count=2,

--- a/magnum/common/rpc.py
+++ b/magnum/common/rpc.py
@@ -152,11 +152,6 @@ def get_client(target, version_cap=None, serializer=None, timeout=None):
 def get_server(target, endpoints, serializer=None):
     assert TRANSPORT is not None
     access_policy = dispatcher.DefaultRPCAccessPolicy
-    if profiler:
-        serializer = ProfilerRequestContextSerializer(serializer)
-    else:
-        serializer = RequestContextSerializer(serializer)
-
     return messaging.get_rpc_server(TRANSPORT,
                                     target,
                                     endpoints,

--- a/magnum/common/rpc.py
+++ b/magnum/common/rpc.py
@@ -142,11 +142,6 @@ def get_transport_url(url_str=None):
 
 def get_client(target, version_cap=None, serializer=None, timeout=None):
     assert TRANSPORT is not None
-    if profiler:
-        serializer = ProfilerRequestContextSerializer(serializer)
-    else:
-        serializer = RequestContextSerializer(serializer)
-
     return messaging.RPCClient(TRANSPORT,
                                target,
                                version_cap=version_cap,

--- a/magnum/common/rpc_service.py
+++ b/magnum/common/rpc_service.py
@@ -79,20 +79,16 @@ class Service(service.Service):
 
 
 class API(object):
-    def __init__(self, transport=None, context=None, topic=None, server=None,
+    def __init__(self, context=None, topic=None, server=None,
                  timeout=None):
         serializer = _init_serializer()
-        if transport is None:
-            exmods = rpc.get_allowed_exmods()
-            transport = messaging.get_rpc_transport(
-                CONF, allowed_remote_exmods=exmods)
         self._context = context
         if topic is None:
             topic = ''
         target = messaging.Target(topic=topic, server=server)
-        self._client = messaging.RPCClient(transport, target,
-                                           serializer=serializer,
-                                           timeout=timeout)
+        self._client = rpc.get_client(target,
+                                      serializer=serializer,
+                                      timeout=timeout)
 
     def _call(self, method, *args, **kwargs):
         return self._client.call(self._context, method, *args, **kwargs)

--- a/magnum/common/rpc_service.py
+++ b/magnum/common/rpc_service.py
@@ -15,7 +15,6 @@
 """Common RPC service and API tools for Magnum."""
 
 import oslo_messaging as messaging
-from oslo_messaging.rpc import dispatcher
 from oslo_service import service
 from oslo_utils import importutils
 
@@ -47,14 +46,11 @@ class Service(service.Service):
     def __init__(self, topic, server, handlers, binary):
         super(Service, self).__init__()
         serializer = _init_serializer()
-        transport = messaging.get_rpc_transport(CONF)
         # TODO(asalkeld) add support for version='x.y'
-        access_policy = dispatcher.DefaultRPCAccessPolicy
         target = messaging.Target(topic=topic, server=server)
-        self._server = messaging.get_rpc_server(transport, target, handlers,
-                                                executor='eventlet',
-                                                serializer=serializer,
-                                                access_policy=access_policy)
+        self._server = rpc.get_server(target, handlers,
+                                      serializer=serializer)
+
         self.binary = binary
         profiler.setup(binary, CONF.host)
 

--- a/magnum/conductor/api.py
+++ b/magnum/conductor/api.py
@@ -25,9 +25,8 @@ CONF = magnum.conf.CONF
 
 @profiler.trace_cls("rpc")
 class API(rpc_service.API):
-    def __init__(self, transport=None, context=None, topic=None):
-        super(API, self).__init__(transport, context,
-                                  topic=CONF.conductor.topic)
+    def __init__(self, context=None, topic=CONF.conductor.topic):
+        super(API, self).__init__(context=context, topic=topic)
 
     # Cluster Operations
 

--- a/magnum/db/sqlalchemy/alembic/versions/1d045384b966_add_insecure_baymodel_attr.py
+++ b/magnum/db/sqlalchemy/alembic/versions/1d045384b966_add_insecure_baymodel_attr.py
@@ -28,7 +28,8 @@ import sqlalchemy as sa  # noqa: E402
 def upgrade():
     insecure_column = sa.Column('insecure', sa.Boolean(), default=False)
     op.add_column('baymodel', insecure_column)
-    baymodel = sa.sql.table('baymodel', insecure_column)
+    baymodel = sa.sql.table('baymodel',
+                            sa.Column('insecure', sa.Boolean(), default=False))
     op.execute(
         baymodel.update().values({'insecure': True})
     )

--- a/magnum/drivers/common/templates/fragments/configure-docker-storage.sh
+++ b/magnum/drivers/common/templates/fragments/configure-docker-storage.sh
@@ -13,7 +13,7 @@ if [ -n "$DOCKER_VOLUME_SIZE" ] && [ "$DOCKER_VOLUME_SIZE" -gt 0 ]; then
     else
         attempts=60
         while [ ${attempts} -gt 0 ]; do
-            device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${DOCKER_VOLUME:0:20}$)
+            device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${DOCKER_VOLUME:0:20} | head -n1)
             if [ -n "${device_name}" ]; then
                 break
             fi

--- a/magnum/drivers/common/templates/kubernetes/fragments/add-proxy.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/add-proxy.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 set +x
 . /etc/sysconfig/heat-params
 set -x

--- a/magnum/drivers/common/templates/kubernetes/fragments/calico-service-v3-3-x.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/calico-service-v3-3-x.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="calico-service-v3-3-x"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/calico-service-v3-3-x.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/calico-service-v3-3-x.sh
@@ -657,7 +657,7 @@ spec:
 EOF
     }
 
-    until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
     do
         echo "Waiting for Kubernetes API..."
         sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 step="calico-service"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
@@ -459,10 +459,10 @@ spec:
                   key: veth_mtu
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
-            # no effect. This should fall within `--cluster-cidr`.
+            # no effect. This should fall within '--cluster-cidr'.
             - name: CALICO_IPV4POOL_CIDR
               value: ${CALICO_IPV4POOL}
-            # Disable file logging so `kubectl logs` works.
+            # Disable file logging so 'kubectl logs' works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.

--- a/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
@@ -837,7 +837,7 @@ EOF
 
 set -x
 
-    until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
     do
         echo "Waiting for Kubernetes API..."
         sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-etcd.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-etcd.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . /etc/sysconfig/heat-params
 
 set -x

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-etcd.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-etcd.sh
@@ -20,7 +20,7 @@ if [ -n "$ETCD_VOLUME_SIZE" ] && [ "$ETCD_VOLUME_SIZE" -gt 0 ]; then
 
     attempts=60
     while [ ${attempts} -gt 0 ]; do
-        device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${ETCD_VOLUME:0:20}$)
+        device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${ETCD_VOLUME:0:20} | head -n1)
         if [ -n "${device_name}" ]; then
             break
         fi

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -60,7 +60,7 @@ cat > /etc/kubernetes/apiserver <<EOF
 KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1"
 KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379,http://127.0.0.1:4001"
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
-KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
+KUBE_ADMISSION_CONTROL="--admission-control=NodeRestriction,${ADMISSION_CONTROL_LIST}"
 KUBE_API_ARGS=""
 EOF
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set +x
 . /etc/sysconfig/heat-params
 set -x
@@ -405,6 +403,7 @@ EOF
 echo "export KUBECONFIG=${ADMIN_KUBECONFIG}" >> /etc/bashrc
 chown root:root ${ADMIN_KUBECONFIG}
 chmod 600 ${ADMIN_KUBECONFIG}
+export KUBECONFIG=${ADMIN_KUBECONFIG}
 
 # Add controller manager args
 KUBE_CONTROLLER_MANAGER_ARGS="--leader-elect=true"

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -46,6 +46,7 @@ elif [ "$NETWORK_DRIVER" = "flannel" ]; then
 fi
 
 
+KUBE_MASTER_URI="https://127.0.0.1:$KUBE_API_PORT"
 mkdir -p /srv/magnum/kubernetes/
 cat > /etc/kubernetes/config <<EOF
 KUBE_LOGTOSTDERR="--logtostderr=true"
@@ -277,16 +278,16 @@ cat > /etc/kubernetes/proxy << EOF
 KUBE_PROXY_ARGS="${KUBE_PROXY_ARGS} ${KUBEPROXY_OPTIONS}"
 EOF
 
-cat > ${PROXY_KUBECONFIG} << EOF
+cat << EOF >> ${PROXY_KUBECONFIG}
 apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: ${CERT_DIR}/ca.crt
-    server: http://127.0.0.1:8080
-  name: kubernetes
+    server: ${KUBE_MASTER_URI}
+  name: ${CLUSTER_UUID}
 contexts:
 - context:
-    cluster: kubernetes
+    cluster: ${CLUSTER_UUID}
     user: kube-proxy
   name: default
 current-context: default
@@ -296,6 +297,8 @@ users:
 - name: kube-proxy
   user:
     as-user-extra: {}
+    client-certificate: ${CERT_DIR}/proxy.crt
+    client-key: ${CERT_DIR}/proxy.key
 EOF
 
 sed -i '
@@ -383,7 +386,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: ${CERT_DIR}/ca.crt
-    server: https://127.0.0.1:$KUBE_API_PORT
+    server: ${KUBE_MASTER_URI}
   name: ${CLUSTER_UUID}
 contexts:
 - context:
@@ -468,11 +471,11 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: ${CERT_DIR}/ca.crt
-    server: http://127.0.0.1:8080
-  name: kubernetes
+    server: ${KUBE_MASTER_URI}
+  name: ${CLUSTER_UUID}
 contexts:
 - context:
-    cluster: kubernetes
+    cluster: ${CLUSTER_UUID}
     user: system:node:${INSTANCE_NAME}
   name: default
 current-context: default
@@ -482,8 +485,8 @@ users:
 - name: system:node:${INSTANCE_NAME}
   user:
     as-user-extra: {}
-    client-certificate: ${CERT_DIR}/server.crt
-    client-key: ${CERT_DIR}/server.key
+    client-certificate: ${CERT_DIR}/kubelet.crt
+    client-key: ${CERT_DIR}/kubelet.key
 EOF
 
 cat > /etc/kubernetes/get_require_kubeconfig.sh << EOF

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -51,14 +51,12 @@ mkdir -p /srv/magnum/kubernetes/
 cat > /etc/kubernetes/config <<EOF
 KUBE_LOGTOSTDERR="--logtostderr=true"
 KUBE_LOG_LEVEL="--v=3"
-KUBE_MASTER="--master=http://127.0.0.1:8080"
 EOF
 cat > /etc/kubernetes/kubelet <<EOF
 KUBELET_ARGS="--fail-swap-on=false"
 EOF
 
 cat > /etc/kubernetes/apiserver <<EOF
-KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1"
 KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379,http://127.0.0.1:4001"
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
 KUBE_ADMISSION_CONTROL="--admission-control=NodeRestriction,${ADMISSION_CONTROL_LIST}"
@@ -303,34 +301,29 @@ EOF
 
 sed -i '
     /^KUBE_ALLOW_PRIV=/ s/=.*/="--allow-privileged='"$KUBE_ALLOW_PRIV"'"/
-    /^KUBE_MASTER=/ s|=.*|="--master=http://127.0.0.1:8080"|
 ' /etc/kubernetes/config
 
 KUBE_API_ARGS="--runtime-config=api/all=true"
 KUBE_API_ARGS="$KUBE_API_ARGS --allow-privileged=$KUBE_ALLOW_PRIV"
 KUBE_API_ARGS="$KUBE_API_ARGS --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP"
 KUBE_API_ARGS="$KUBE_API_ARGS $KUBEAPI_OPTIONS"
-if [ "$TLS_DISABLED" == "True" ]; then
-    KUBE_API_ADDRESS="--insecure-bind-address=0.0.0.0 --insecure-port=$KUBE_API_PORT"
-else
-    KUBE_API_ADDRESS="--bind-address=0.0.0.0 --secure-port=$KUBE_API_PORT"
-    # insecure port is used internaly
-    KUBE_API_ADDRESS="$KUBE_API_ADDRESS --insecure-bind-address=127.0.0.1 --insecure-port=8080"
-    KUBE_API_ARGS="$KUBE_API_ARGS --authorization-mode=Node,RBAC --tls-cert-file=$CERT_DIR/server.crt"
-    KUBE_API_ARGS="$KUBE_API_ARGS --tls-private-key-file=$CERT_DIR/server.key"
-    KUBE_API_ARGS="$KUBE_API_ARGS --client-ca-file=$CERT_DIR/ca.crt"
-    KUBE_API_ARGS="$KUBE_API_ARGS --service-account-key-file=${CERT_DIR}/service_account.key"
-    KUBE_API_ARGS="$KUBE_API_ARGS --kubelet-certificate-authority=${CERT_DIR}/ca.crt --kubelet-client-certificate=${CERT_DIR}/server.crt --kubelet-client-key=${CERT_DIR}/server.key --kubelet-https=true"
-    # Allow for metrics-server/aggregator communication
-    KUBE_API_ARGS="${KUBE_API_ARGS} \
-        --proxy-client-cert-file=${CERT_DIR}/server.crt \
-        --proxy-client-key-file=${CERT_DIR}/server.key \
-        --requestheader-allowed-names=front-proxy-client,kube,kubernetes \
-        --requestheader-client-ca-file=${CERT_DIR}/ca.crt \
-        --requestheader-extra-headers-prefix=X-Remote-Extra- \
-        --requestheader-group-headers=X-Remote-Group \
-        --requestheader-username-headers=X-Remote-User"
-fi
+KUBE_API_ADDRESS="--bind-address=0.0.0.0 --secure-port=$KUBE_API_PORT"
+KUBE_API_ARGS="$KUBE_API_ARGS --authorization-mode=Node,RBAC --tls-cert-file=$CERT_DIR/server.crt"
+KUBE_API_ARGS="$KUBE_API_ARGS --tls-private-key-file=$CERT_DIR/server.key"
+KUBE_API_ARGS="$KUBE_API_ARGS --client-ca-file=$CERT_DIR/ca.crt"
+KUBE_API_ARGS="$KUBE_API_ARGS --service-account-key-file=${CERT_DIR}/service_account.key"
+KUBE_API_ARGS="$KUBE_API_ARGS --service-account-signing-key-file=${CERT_DIR}/service_account_private.key"
+KUBE_API_ARGS="$KUBE_API_ARGS --service-account-issuer=https://kubernetes.default.svc.cluster.local"
+KUBE_API_ARGS="$KUBE_API_ARGS --kubelet-certificate-authority=${CERT_DIR}/ca.crt --kubelet-client-certificate=${CERT_DIR}/server.crt --kubelet-client-key=${CERT_DIR}/server.key --kubelet-https=true"
+# Allow for metrics-server/aggregator communication
+KUBE_API_ARGS="${KUBE_API_ARGS} \
+    --proxy-client-cert-file=${CERT_DIR}/server.crt \
+    --proxy-client-key-file=${CERT_DIR}/server.key \
+    --requestheader-allowed-names=front-proxy-client,kube,kubernetes \
+    --requestheader-client-ca-file=${CERT_DIR}/ca.crt \
+    --requestheader-extra-headers-prefix=X-Remote-Extra- \
+    --requestheader-group-headers=X-Remote-Group \
+    --requestheader-username-headers=X-Remote-User"
 
 KUBE_ADMISSION_CONTROL=""
 if [ -n "${ADMISSION_CONTROL_LIST}" ] && [ "${TLS_DISABLED}" == "False" ]; then
@@ -409,7 +402,7 @@ chmod 600 ${ADMIN_KUBECONFIG}
 export KUBECONFIG=${ADMIN_KUBECONFIG}
 
 # Add controller manager args
-KUBE_CONTROLLER_MANAGER_ARGS="--leader-elect=true"
+KUBE_CONTROLLER_MANAGER_ARGS="--leader-elect=true --kubeconfig=/etc/kubernetes/admin.conf"
 KUBE_CONTROLLER_MANAGER_ARGS="$KUBE_CONTROLLER_MANAGER_ARGS --cluster-name=${CLUSTER_UUID}"
 KUBE_CONTROLLER_MANAGER_ARGS="${KUBE_CONTROLLER_MANAGER_ARGS} --allocate-node-cidrs=true"
 KUBE_CONTROLLER_MANAGER_ARGS="${KUBE_CONTROLLER_MANAGER_ARGS} --cluster-cidr=${PODS_NETWORK_CIDR}"
@@ -435,7 +428,7 @@ sed -i '
     /^KUBE_CONTROLLER_MANAGER_ARGS=/ s#\(KUBE_CONTROLLER_MANAGER_ARGS\).*#\1="'"${KUBE_CONTROLLER_MANAGER_ARGS}"'"#
 ' /etc/kubernetes/controller-manager
 
-sed -i '/^KUBE_SCHEDULER_ARGS=/ s/=.*/="--leader-elect=true"/' /etc/kubernetes/scheduler
+sed -i '/^KUBE_SCHEDULER_ARGS=/ s#=.*#="--leader-elect=true --kubeconfig=/etc/kubernetes/admin.conf"#' /etc/kubernetes/scheduler
 
 $ssh_cmd mkdir -p /etc/kubernetes/manifests
 KUBELET_ARGS="--register-node=true --pod-manifest-path=/etc/kubernetes/manifests --hostname-override=${INSTANCE_NAME}"

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -95,7 +95,7 @@ ExecStart=/bin/bash -c '/usr/bin/podman run --name kube-apiserver \\
     --volume /etc/pki/tls/certs:/usr/share/ca-certificates:ro \\
     \${CONTAINER_INFRA_PREFIX:-k8s.gcr.io/}hyperkube:\${KUBE_TAG} \\
     kube-apiserver \\
-    \$KUBE_LOGTOSTDERR \$KUBE_LOG_LEVEL \$KUBE_ETCD_SERVERS \$KUBE_API_ADDRESS \$KUBE_API_PORT \$KUBELET_PORT \$KUBE_SERVICE_ADDRESSES \$KUBE_ADMISSION_CONTROL \$KUBE_API_ARGS'
+    \$KUBE_LOGTOSTDERR \$KUBE_LOG_LEVEL \$KUBE_ETCD_SERVERS \$KUBE_API_ADDRESS \$KUBELET_PORT \$KUBE_SERVICE_ADDRESSES \$KUBE_ADMISSION_CONTROL \$KUBE_API_ARGS'
 ExecStop=-/usr/bin/podman stop kube-apiserver
 Delegate=yes
 Restart=always

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-master.sh
@@ -453,11 +453,11 @@ if [ -f /etc/sysconfig/docker ] ; then
     sed -i 's/\-\-log\-driver\=journald//g' /etc/sysconfig/docker
     # json-file is required for conformance.
     # https://docs.docker.com/config/containers/logging/json-file/
-    sed -i -E 's/^OPTIONS=("|'"'"')/OPTIONS=\1--log-driver=json-file --log-opt max-size=10m --log-opt max-file=5 /' /etc/sysconfig/docker
-
+    DOCKER_OPTIONS="--log-driver=json-file --log-opt max-size=10m --log-opt max-file=5"
     if [ -n "${INSECURE_REGISTRY_URL}" ]; then
-        echo "INSECURE_REGISTRY='--insecure-registry ${INSECURE_REGISTRY_URL}'" >> /etc/sysconfig/docker
+        DOCKER_OPTIONS="${DOCKER_OPTIONS} --insecure-registry ${INSECURE_REGISTRY_URL}"
     fi
+    sed -i -E 's/^OPTIONS=("|'"'"')/OPTIONS=\1'"${DOCKER_OPTIONS}"' /' /etc/sysconfig/docker
 fi
 
 KUBELET_ARGS="${KUBELET_ARGS} --network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-minion.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-minion.sh
@@ -55,7 +55,6 @@ mkdir -p /srv/magnum/kubernetes/
 cat > /etc/kubernetes/config <<EOF
 KUBE_LOGTOSTDERR="--logtostderr=true"
 KUBE_LOG_LEVEL="--v=3"
-KUBE_MASTER="--master=http://127.0.0.1:8080"
 EOF
 cat > /etc/kubernetes/kubelet <<EOF
 KUBELET_ARGS="--fail-swap-on=false"

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-minion.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-minion.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set +x
 . /etc/sysconfig/heat-params
 set -x

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-minion.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-kubernetes-minion.sh
@@ -263,11 +263,11 @@ if [ -f /etc/sysconfig/docker ] ; then
     sed -i 's/\-\-log\-driver\=journald//g' /etc/sysconfig/docker
     # json-file is required for conformance.
     # https://docs.docker.com/config/containers/logging/json-file/
-    sed -i -E 's/^OPTIONS=("|'"'"')/OPTIONS=\1--log-driver=json-file --log-opt max-size=10m --log-opt max-file=5 /' /etc/sysconfig/docker
-
+    DOCKER_OPTIONS="--log-driver=json-file --log-opt max-size=10m --log-opt max-file=5"
     if [ -n "${INSECURE_REGISTRY_URL}" ]; then
-        echo "INSECURE_REGISTRY='--insecure-registry ${INSECURE_REGISTRY_URL}'" >> /etc/sysconfig/docker
+        DOCKER_OPTIONS="${DOCKER_OPTIONS} --insecure-registry ${INSECURE_REGISTRY_URL}"
     fi
+    sed -i -E 's/^OPTIONS=("|'"'"')/OPTIONS=\1'"${DOCKER_OPTIONS}"' /' /etc/sysconfig/docker
 fi
 
 KUBELET_ARGS="${KUBELET_ARGS} --pod-infra-container-image=${CONTAINER_INFRA_PREFIX:-gcr.io/google_containers/}pause:3.1"

--- a/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
@@ -298,7 +298,7 @@ EOF
 }
 
 echo "Waiting for Kubernetes API..."
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
 do
     sleep 5
 done

--- a/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="core-dns-service"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/disable-selinux.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/disable-selinux.sh
@@ -1,5 +1,4 @@
 #cloud-boothook
-#!/bin/sh
 
 setenforce `[[ "$SELINUX_MODE" == "enforcing" ]] && echo 1 || echo 0`
 sed -i '

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-healing.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-healing.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="enable-node-problem-detector"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-healing.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-healing.sh
@@ -125,7 +125,7 @@ EOF
     }
 
     echo "Waiting for Kubernetes API..."
-    until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
     do
         sleep 5
     done

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-scaling.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-scaling.sh
@@ -170,7 +170,7 @@ EOF
     }
 
     echo "Waiting for Kubernetes API..."
-    until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
     do
         sleep 5
     done

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-scaling.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-scaling.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="enable-auto-scaling"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-cert-api-manager.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-cert-api-manager.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="enable-cert-api-manager"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
@@ -499,7 +499,7 @@ spec:
 EOF
 
     echo "Waiting for Kubernetes API..."
-    until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
     do
         sleep 5
     done

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
@@ -246,6 +246,15 @@ spec:
         app: csi-cinder-controllerplugin
     spec:
       serviceAccount: csi-cinder-controller-sa
+      tolerations:
+        # Make sure the pod can be scheduled on master kubelet.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       containers:
         - name: csi-attacher
           image: ${CONTAINER_INFRA_PREFIX:-quay.io/k8scsi/}csi-attacher:${CSI_ATTACHER_TAG}

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="enable-cinder-csi"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-helm-tiller.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-helm-tiller.sh
@@ -222,7 +222,7 @@ data:
 EOF
     }
 
-    until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
     do
         echo "Waiting for Kubernetes API..."
         sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-helm-tiller.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-helm-tiller.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 . /etc/sysconfig/heat-params
 
 step="enable-helm-tiller"

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-ingress-controller.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-ingress-controller.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="enable-ingress-controller"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-ingress-octavia.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-ingress-octavia.sh
@@ -112,7 +112,7 @@ EOF
 writeFile $OCTAVIA_INGRESS_CONTROLLER "$OCTAVIA_INGRESS_CONTROLLER_CONTENT"
 
 echo "Waiting for Kubernetes API..."
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
 do
     sleep 5
 done

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-ingress-traefik.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-ingress-traefik.sh
@@ -169,7 +169,7 @@ EOF
 
 writeFile $INGRESS_TRAEFIK_MANIFEST "$INGRESS_TRAEFIK_MANIFEST_CONTENT"
 
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
 do
     echo "Waiting for Kubernetes API..."
     sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
@@ -73,8 +73,8 @@ metadata:
 data:
   syncConfig: |
     role-mappings:
-      keystone-role: member
-      groups: []
+      - keystone-role: member
+        groups: []
 EOF
     }
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
@@ -64,6 +64,17 @@ metadata:
 data:
   policies: |
     $KEYSTONE_AUTH_DEFAULT_POLICY
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keystone-sync-policy
+  namespace: kube-system
+data:
+  syncConfig: |
+    role-mappings:
+      keystone-role: member
+      groups: []
 EOF
     }
 
@@ -121,6 +132,8 @@ spec:
             - k8s-keystone-auth-policy
             - --keystone-url
             - ${AUTH_URL}
+            - --sync-configmap-name
+            - keystone-sync-policy
             - --keystone-ca-file
             - /etc/kubernetes/ca-bundle.crt
             - --listen

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
@@ -166,7 +166,7 @@ spec:
 EOF
     }
 
-    until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
     do
         echo "Waiting for Kubernetes API..."
         sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-keystone-auth.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . /etc/sysconfig/heat-params
 
 step="enable-keystone-auth"

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-prometheus-monitoring.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-prometheus-monitoring.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="enable-prometheus-monitoring"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-prometheus-monitoring.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-prometheus-monitoring.sh
@@ -462,7 +462,7 @@ if [ "$(echo $PROMETHEUS_MONITORING | tr '[:upper:]' '[:lower:]')" = "true" ]; t
 
     # Write the binary for enable-monitoring
     KUBE_MON_BIN_CONTENT='''#!/bin/sh
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
 do
     echo "Waiting for Kubernetes API..."
     sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-services-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-services-master.sh
@@ -27,7 +27,7 @@ for action in enable restart; do
 done
 
 # Label self as master
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ] && \
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ] && \
     kubectl patch node ${INSTANCE_NAME} \
         --patch '{"metadata": {"labels": {"node-role.kubernetes.io/master": ""}}}'
 do

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-services-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-services-master.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . /etc/sysconfig/heat-params
 
 ssh_cmd="ssh -F /srv/magnum/.ssh/config root@localhost"

--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-services-minion.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-services-minion.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 set -x
 
 ssh_cmd="ssh -F /srv/magnum/.ssh/config root@localhost"

--- a/magnum/drivers/common/templates/kubernetes/fragments/flannel-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/flannel-service.sh
@@ -260,7 +260,7 @@ EOF
 
     if [ "$MASTER_INDEX" = "0" ]; then
 
-        until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+        until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
         do
             echo "Waiting for Kubernetes API..."
             sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/flannel-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/flannel-service.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -e
 set +x
 . /etc/sysconfig/heat-params

--- a/magnum/drivers/common/templates/kubernetes/fragments/install-clients.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-clients.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 step="install-clients"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/install-clients.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-clients.sh
@@ -31,6 +31,7 @@ do
 done
 echo "INFO Installed kubectl."
 
-echo "PATH=/srv/magnum/bin:\$PATH" >> /etc/bashrc
+echo "export PATH=/srv/magnum/bin:\$PATH" >> /etc/bashrc
+export PATH=/srv/magnum/bin:$PATH
 
 printf "Finished running ${step}\n"

--- a/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set +x
 
 echo "START: install cri"

--- a/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
@@ -10,10 +10,10 @@ ssh_cmd="ssh -F /srv/magnum/.ssh/config root@localhost"
 if [ "${CONTAINER_RUNTIME}" = "containerd"  ] ; then
     $ssh_cmd systemctl disable docker
     if [ -z "${CONTAINERD_TARBALL_URL}"  ] ; then
-        CONTAINERD_TARBALL_URL="https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz"
+        CONTAINERD_TARBALL_URL="https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz"
     fi
     i=0
-    until curl -o /srv/magnum/cri-containerd.tar.gz "${CONTAINERD_TARBALL_URL}"
+    until curl -o /srv/magnum/cri-containerd.tar.gz -L "${CONTAINERD_TARBALL_URL}"
     do
         i=$((i + 1))
         [ $i -lt 5 ] || break;

--- a/magnum/drivers/common/templates/kubernetes/fragments/install-helm-modules.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-helm-modules.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 step="install-helm-modules"
 echo "START: ${step}"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/install-helm-modules.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-helm-modules.sh
@@ -20,7 +20,7 @@ fi
 ssh_cmd="ssh -F /srv/magnum/.ssh/config root@localhost"
 
 echo "Waiting for Kubernetes API..."
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]; do
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ]; do
     sleep 5
 done
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="kube-apiserver-to-kubelet-role"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
@@ -6,7 +6,7 @@ set +x
 set -x
 
 echo "Waiting for Kubernetes API..."
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
 do
     sleep 5
 done

--- a/magnum/drivers/common/templates/kubernetes/fragments/kube-dashboard-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/kube-dashboard-service.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 step="kube-dashboard-service"
 printf "Starting to run ${step}\n"
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/kube-dashboard-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/kube-dashboard-service.sh
@@ -4,7 +4,7 @@ printf "Starting to run ${step}\n"
 . /etc/sysconfig/heat-params
 
 echo "Waiting for Kubernetes API..."
-until  [ "ok" = "$(curl --silent http://127.0.0.1:8080/healthz)" ]
+until  [ "ok" = "$(kubectl get --raw='/healthz')" ]
 do
     sleep 5
 done

--- a/magnum/drivers/common/templates/kubernetes/fragments/make-cert-client.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/make-cert-client.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 # Copyright 2014 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/magnum/drivers/common/templates/kubernetes/fragments/make-cert.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/make-cert.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 # Copyright 2014 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/magnum/drivers/common/templates/kubernetes/fragments/start-container-agent.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/start-container-agent.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -x
 set +u
 HTTP_PROXY="$HTTP_PROXY"

--- a/magnum/drivers/common/templates/kubernetes/fragments/upgrade-kubernetes.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/upgrade-kubernetes.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 . /etc/sysconfig/heat-params
 set -x
 

--- a/magnum/drivers/common/templates/kubernetes/fragments/wc-notify-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/wc-notify-master.sh
@@ -11,7 +11,7 @@ WC_NOTIFY_SERVICE=/etc/systemd/system/wc-notify.service
 
 cat > $WC_NOTIFY_BIN <<EOF
 #!/bin/bash -v
-until  [ "ok" = "\$(curl --silent http://127.0.0.1:8080/healthz)" ]
+until  [ "ok" = "\$(kubectl get --raw='/healthz')" ]
 do
     echo "Waiting for Kubernetes API..."
     sleep 5

--- a/magnum/drivers/common/templates/kubernetes/fragments/wc-notify-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/wc-notify-master.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . /etc/sysconfig/heat-params
 
 if [ "$VERIFY_CA" == "True" ]; then

--- a/magnum/drivers/common/templates/kubernetes/fragments/write-heat-params-master.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/write-heat-params-master.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 echo "START: write-heat-params"
 
 arch=$(uname -m)

--- a/magnum/drivers/common/templates/kubernetes/fragments/write-heat-params.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/write-heat-params.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 echo "START: write-heat-params"
 
 arch=$(uname -m)

--- a/magnum/drivers/common/templates/kubernetes/fragments/write-kube-os-config.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/write-kube-os-config.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 set +x
 . /etc/sysconfig/heat-params
 set -x

--- a/magnum/drivers/common/templates/kubernetes/fragments/write-kube-os-config.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/write-kube-os-config.sh
@@ -3,7 +3,6 @@ set +x
 set -x
 
 $ssh_cmd mkdir -p /etc/kubernetes/
-$ssh_cmd cp /etc/pki/tls/certs/ca-bundle.crt /etc/kubernetes/ca-bundle.crt
 
 if [ -n "${TRUST_ID}" ]; then
     KUBE_OS_CLOUD_CONFIG=/etc/kubernetes/cloud-config

--- a/magnum/drivers/common/templates/kubernetes/helm/ingress-nginx.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/ingress-nginx.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set +x
 . /etc/sysconfig/heat-params
 set -ex

--- a/magnum/drivers/common/templates/kubernetes/helm/ingress-nginx.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/ingress-nginx.sh
@@ -13,7 +13,7 @@ if [ "$(echo ${INGRESS_CONTROLLER} | tr '[:upper:]' '[:lower:]')" = "nginx" ]; t
     cat << EOF >> ${HELM_CHART_DIR}/requirements.yaml
 - name: ${CHART_NAME}
   version: ${NGINX_INGRESS_CONTROLLER_CHART_TAG}
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
 EOF
 
     cat << EOF >> ${HELM_CHART_DIR}/values.yaml

--- a/magnum/drivers/common/templates/kubernetes/helm/metrics-server.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/metrics-server.sh
@@ -13,7 +13,7 @@ if [ "$(echo ${METRICS_SERVER_ENABLED} | tr '[:upper:]' '[:lower:]')" = "true" ]
     cat << EOF >> ${HELM_CHART_DIR}/requirements.yaml
 - name: ${CHART_NAME}
   version: ${METRICS_SERVER_CHART_TAG}
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
 EOF
 
     cat << EOF >> ${HELM_CHART_DIR}/values.yaml

--- a/magnum/drivers/common/templates/kubernetes/helm/metrics-server.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/metrics-server.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set +x
 . /etc/sysconfig/heat-params
 set -ex

--- a/magnum/drivers/common/templates/kubernetes/helm/prometheus-adapter.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/prometheus-adapter.sh
@@ -15,7 +15,7 @@ if [ "$(echo ${MONITORING_ENABLED} | tr '[:upper:]' '[:lower:]')" = "true" ] && 
     cat << EOF >> ${HELM_CHART_DIR}/requirements.yaml
 - name: ${CHART_NAME}
   version: ${PROMETHEUS_ADAPTER_CHART_TAG}
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://prometheus-community.github.io/helm-charts
 EOF
 
     cat << EOF >> ${HELM_CHART_DIR}/values.yaml

--- a/magnum/drivers/common/templates/kubernetes/helm/prometheus-adapter.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/prometheus-adapter.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set +x
 . /etc/sysconfig/heat-params
 set -ex

--- a/magnum/drivers/common/templates/kubernetes/helm/prometheus-operator.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/prometheus-operator.sh
@@ -54,10 +54,13 @@ prometheus-operator:
       #     memory: 256Mi
       priorityClassName: "system-cluster-critical"
 
-
   # Dashboard
   grafana:
+    image:
+      repository: ${CONTAINER_INFRA_PREFIX:-grafana/}grafana
     #enabled: ${ENABLE_GRAFANA}
+    sidecar:
+      image: ${CONTAINER_INFRA_PREFIX:-kiwigrid/}k8s-sidecar:0.1.99
     resources:
       requests:
         cpu: 100m

--- a/magnum/drivers/common/templates/kubernetes/helm/prometheus-operator.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/prometheus-operator.sh
@@ -13,7 +13,7 @@ if [ "$(echo ${MONITORING_ENABLED} | tr '[:upper:]' '[:lower:]')" = "true" ]; th
     cat << EOF >> ${HELM_CHART_DIR}/requirements.yaml
 - name: ${CHART_NAME}
   version: ${PROMETHEUS_OPERATOR_CHART_TAG}
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://prometheus-community.github.io/helm-charts
 EOF
 
     # Calculate resources needed to run the Prometheus Monitoring Solution

--- a/magnum/drivers/common/templates/kubernetes/helm/prometheus-operator.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/prometheus-operator.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set +x
 . /etc/sysconfig/heat-params
 set -ex

--- a/magnum/drivers/heat/driver.py
+++ b/magnum/drivers/heat/driver.py
@@ -304,7 +304,10 @@ class KubernetesDriver(HeatDriver):
         if keystone.is_octavia_enabled():
             LOG.info("Starting to delete loadbalancers for cluster %s",
                      cluster.uuid)
-            octavia.delete_loadbalancers(context, cluster)
+            try:
+                octavia.delete_loadbalancers(context, cluster)
+            except exception.PreDeletionFailed as e:
+                LOG.error(str(e))
 
     def upgrade_cluster(self, context, cluster, cluster_template,
                         max_batch_size, nodegroup, scale_manager=None,

--- a/magnum/drivers/heat/k8s_fedora_template_def.py
+++ b/magnum/drivers/heat/k8s_fedora_template_def.py
@@ -118,6 +118,7 @@ class K8sFedoraTemplateDefinition(k8s_template_def.K8sTemplateDefinition):
                       'min_node_count', 'max_node_count', 'npd_enabled',
                       'ostree_remote', 'ostree_commit',
                       'use_podman', 'kube_image_digest',
+                      'vnic_type', 'master_vnic_type',
                       'metrics_scraper_tag']
 
         labels = self._get_relevant_labels(cluster, kwargs)

--- a/magnum/drivers/k8s_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_coreos_v1/templates/kubecluster.yaml
@@ -413,12 +413,6 @@ parameters:
       domain name for cluster DNS
     default: "cluster.local"
 
-  etcd_volume_size:
-    type: number
-    description: >
-      size of the cinder volume for etcd storage
-    default: 0
-
   openstack_ca:
     type: string
     hidden: true

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -901,7 +901,7 @@ parameters:
   containerd_version:
     type: string
     description: The containerd version to download from https://storage.googleapis.com/cri-containerd-release/
-    default: '1.2.8'
+    default: '1.4.3'
 
   containerd_tarball_url:
     type: string
@@ -911,7 +911,7 @@ parameters:
   containerd_tarball_sha256:
     type: string
     description: sha256 of the target containerd tarball.
-    default: '1f2f0fb928179df90492a83c326a194b8e9d992538498efb44cbb6ef15465627'
+    default: '34a161e3f459fd337b03141a339eeb1a56c5c811922fe72012d2dac9fa5542f1'
 
   post_install_manifest_url:
     type: string

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -1278,6 +1278,7 @@ resources:
         list_join:
           - "\n"
           -
+            - "#!/bin/bash"
             - get_file: ../../common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
             - get_file: ../../common/templates/kubernetes/fragments/core-dns-service.sh
             - if:

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -925,6 +925,16 @@ parameters:
     description: The allowed CIDR list for master load balancer
     default: []
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to worker nodes
+    default: "normal"
+
+  master_vnic_type:
+    type: string
+    description: vnic type for ports attached to master nodes
+    default: "normal"
+
 resources:
 
   ######################################################################
@@ -1165,6 +1175,7 @@ resources:
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
           traefik_ingress_controller_tag: {get_param: traefik_ingress_controller_tag}
+          vnic_type: {get_param: master_vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           fixed_network: {get_attr: [network, fixed_network]}
@@ -1395,6 +1406,7 @@ resources:
           registry_chunksize: {get_param: registry_chunksize}
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
+          vnic_type: {get_param: vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           auth_url: {get_param: auth_url}

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
@@ -706,6 +706,7 @@ resources:
         list_join:
           - "\n"
           -
+            - "#!/bin/bash"
             - str_replace:
                 template: {get_file: ../../common/templates/kubernetes/fragments/write-heat-params-master.sh}
                 params:
@@ -995,7 +996,11 @@ resources:
       - name: ostree_remote_input
       - name: ostree_commit_input
       config:
-        get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
+        list_join:
+          - "\n"
+          -
+            - "#!/bin/bash"
+            - get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
 
   upgrade_kubernetes_deployment:
     type: OS::Heat::SoftwareDeployment

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
@@ -838,6 +838,7 @@ resources:
             - get_file: ../../common/templates/kubernetes/fragments/install-cri.sh
             - get_file: ../../common/templates/kubernetes/fragments/install-clients.sh
             - get_file: ../../common/templates/kubernetes/fragments/make-cert.sh
+            - get_file: ../../common/templates/kubernetes/fragments/make-cert-client.sh
             - str_replace:
                 template: {get_file: ../../common/templates/kubernetes/fragments/enable-cert-api-manager.sh}
                 params:

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
@@ -910,7 +910,6 @@ resources:
       block_device_mapping_v2:
         - boot_index: 0
           volume_id: {get_resource: kube_node_volume}
-          delete_on_termination: true
 
   kube_master_eth0:
     type: OS::Neutron::Port

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
@@ -104,6 +104,10 @@ parameters:
       the docker cgroup driver.
     default: "cgroupfs"
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -923,6 +927,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_master_floating:
     type: Magnum::Optional::KubeMaster::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
@@ -400,6 +400,7 @@ resources:
         list_join:
           - "\n"
           -
+            - "#!/bin/bash"
             - str_replace:
                 template: {get_file: ../../common/templates/kubernetes/fragments/write-heat-params.sh}
                 params:
@@ -582,7 +583,11 @@ resources:
       - name: ostree_remote_input
       - name: ostree_commit_input
       config:
-        get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
+        list_join:
+          - "\n"
+          -
+            - "#!/bin/bash"
+            - get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
 
   upgrade_kubernetes_deployment:
     type: OS::Heat::SoftwareDeployment

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
@@ -533,7 +533,6 @@ resources:
       block_device_mapping_v2:
         - boot_index: 0
           volume_id: {get_resource: kube_node_volume}
-          delete_on_termination: true
 
   kube_minion_eth0:
     type: OS::Neutron::Port

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
@@ -164,6 +164,10 @@ parameters:
     type: string
     description: ID of the security group for kubernetes minion.
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -545,6 +549,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_minion_floating:
     type: Magnum::Optional::KubeMinion::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/fcct-config.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/fcct-config.yaml
@@ -5,9 +5,9 @@
 #
 # You can use podman or docker to generate the ignition formatted json:
 # podman run --rm \
-# -v ./fcct-config.yaml:/config.fcc:z \
-# quay.io/coreos/fcct:release \
-# --pretty --strict --input /config.fcc > ./user_data.json
+#   -v $(pwd)/fcct-config.yaml:/config.fcc \
+#   quay.io/coreos/fcct:release \
+#   --pretty --strict /config.fcc > ./user_data.json
 #
 # [0] https://github.com/coreos/fcct
 # [1] https://github.com/coreos/fedora-coreos-docs/blob/master/modules/ROOT/pages/producing-ign.adoc
@@ -69,6 +69,18 @@ storage:
           # -1 is unlimited
           # 50m
           max_log_size = 52428800
+    - path: /etc/containers/__REGISTRIES_CONF__
+      # 420 (decimal) == 644 (octal)
+      mode: 420
+      user:
+        name: root
+      group:
+        name: root
+      append:
+        - inline: |
+            [[registry]]
+            location = "__INSECURE_REGISTRY_URL__"
+            insecure = true
     - path: /etc/hostname
       # 420 (decimal) == 644 (octal)
       mode: 420

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/fcct-config.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/fcct-config.yaml
@@ -112,7 +112,9 @@ storage:
           done
 
           /usr/bin/update-ca-trust
-          
+          mkdir /etc/kubernetes/
+          cp /etc/pki/tls/certs/ca-bundle.crt /etc/kubernetes/ca-bundle.crt
+
           HTTP_PROXY="__HTTP_PROXY__"
           HTTPS_PROXY="__HTTPS_PROXY__"
           NO_PROXY="__NO_PROXY__"

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -222,7 +222,7 @@ parameters:
     type: string
     description: >
       List of admission control plugins to activate
-    default: "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
+    default: "NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,RuntimeClass"
 
   kube_allow_priv:
     type: string

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -1340,7 +1340,7 @@ resources:
                 template: {get_file: ../../common/templates/kubernetes/helm/prometheus-operator.sh}
                 params:
                   "${GRAFANA_ADMIN_PASSWD}": {get_param: grafana_admin_passwd}
-                  "${KUBE_MASTERS_PRIVATE}": {get_attr: [kube_masters, kube_master_external_ip]}
+                  "${KUBE_MASTERS_PRIVATE}": {get_attr: [kube_masters, kube_master_ip]}
             - get_file: ../../common/templates/kubernetes/helm/prometheus-adapter.sh
             - get_file: ../../common/templates/kubernetes/helm/ingress-nginx.sh
             - get_file: ../../common/templates/kubernetes/fragments/install-helm-modules.sh

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -222,7 +222,7 @@ parameters:
     type: string
     description: >
       List of admission control plugins to activate
-    default: "NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,RuntimeClass"
+    default: "PodSecurityPolicy,NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,RuntimeClass"
 
   kube_allow_priv:
     type: string

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -1307,6 +1307,7 @@ resources:
         list_join:
           - "\n"
           -
+            - "#!/bin/bash"
             - get_file: ../../common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
             - get_file: ../../common/templates/kubernetes/fragments/core-dns-service.sh
             - if:

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -1308,6 +1308,7 @@ resources:
           - "\n"
           -
             - "#!/bin/bash"
+            - "source /etc/bashrc"
             - get_file: ../../common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
             - get_file: ../../common/templates/kubernetes/fragments/core-dns-service.sh
             - if:

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -943,6 +943,16 @@ parameters:
     description: The allowed CIDR list for master load balancer
     default: []
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to worker nodes
+    default: "normal"
+
+  master_vnic_type:
+    type: string
+    description: vnic type for ports attached to master nodes
+    default: "normal"
+
 resources:
 
   ######################################################################
@@ -1193,6 +1203,7 @@ resources:
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
           traefik_ingress_controller_tag: {get_param: traefik_ingress_controller_tag}
+          vnic_type: {get_param: master_vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           fixed_network: {get_attr: [network, fixed_network]}
@@ -1426,6 +1437,7 @@ resources:
           registry_chunksize: {get_param: registry_chunksize}
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
+          vnic_type: {get_param: vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           auth_url: {get_param: auth_url}

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -850,6 +850,7 @@ resources:
             - get_file: ../../common/templates/kubernetes/fragments/install-cri.sh
             - get_file: ../../common/templates/kubernetes/fragments/install-clients.sh
             - get_file: ../../common/templates/kubernetes/fragments/make-cert.sh
+            - get_file: ../../common/templates/kubernetes/fragments/make-cert-client.sh
             - str_replace:
                 template: {get_file: ../../common/templates/kubernetes/fragments/enable-cert-api-manager.sh}
                 params:

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -717,6 +717,7 @@ resources:
         list_join:
           - "\n"
           -
+            - "#!/bin/bash"
             - str_replace:
                 template: {get_file: ../../common/templates/kubernetes/fragments/write-heat-params-master.sh}
                 params:
@@ -1006,7 +1007,11 @@ resources:
       - name: ostree_remote_input
       - name: ostree_commit_input
       config:
-        get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
+        list_join:
+          - "\n"
+          -
+            - "#!/bin/bash"
+            - get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
 
   upgrade_kubernetes_deployment:
     type: OS::Heat::SoftwareDeployment

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -708,6 +708,14 @@ resources:
                   __HTTPS_PROXY__: {get_param: https_proxy}
                   __NO_PROXY__: {get_param: no_proxy}
                   __SELINUX_MODE__: {get_param: selinux_mode}
+                  __INSECURE_REGISTRY_URL__: {get_param: insecure_registry_url}
+                  __REGISTRIES_CONF__:
+                    if:
+                      - equals:
+                        - get_param: insecure_registry_url
+                        - ""
+                      - ".registries.conf"
+                      - "registries.conf"
 
   master_config:
     type: OS::Heat::SoftwareConfig

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -920,7 +920,6 @@ resources:
       block_device_mapping_v2:
         - boot_index: 0
           volume_id: {get_resource: kube_node_volume}
-          delete_on_termination: true
 
   kube_master_eth0:
     type: OS::Neutron::Port

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -108,6 +108,10 @@ parameters:
       the docker cgroup driver.
     default: "cgroupfs"
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -941,6 +945,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_master_floating:
     type: Magnum::Optional::KubeMaster::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -402,6 +402,7 @@ resources:
         list_join:
           - "\n"
           -
+            - "#!/bin/bash"
             - str_replace:
                 template: {get_file: ../../common/templates/kubernetes/fragments/write-heat-params.sh}
                 params:
@@ -582,7 +583,11 @@ resources:
       - name: ostree_remote_input
       - name: ostree_commit_input
       config:
-        get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
+        list_join:
+          - "\n"
+          -
+            - "#!/bin/bash"
+            - get_file: ../../common/templates/kubernetes/fragments/upgrade-kubernetes.sh
 
   upgrade_kubernetes_deployment:
     type: OS::Heat::SoftwareDeployment

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -387,6 +387,14 @@ resources:
                   __HTTPS_PROXY__: {get_param: https_proxy}
                   __NO_PROXY__: {get_param: no_proxy}
                   __SELINUX_MODE__: {get_param: selinux_mode}
+                  __INSECURE_REGISTRY_URL__: {get_param: insecure_registry_url}
+                  __REGISTRIES_CONF__:
+                    if:
+                      - equals:
+                        - get_param: insecure_registry_url
+                        - ""
+                      - ".registries.conf"
+                      - "registries.conf"
 
   ######################################################################
   #

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -533,7 +533,6 @@ resources:
       block_device_mapping_v2:
         - boot_index: 0
           volume_id: {get_resource: kube_node_volume}
-          delete_on_termination: true
 
   kube_minion_eth0:
     type: OS::Neutron::Port

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -465,7 +465,6 @@ resources:
                   $CONTAINERD_TARBALL_SHA256: {get_param: containerd_tarball_sha256}
             - get_file: ../../common/templates/kubernetes/fragments/install-cri.sh
             - get_file: ../../common/templates/kubernetes/fragments/install-clients.sh
-            - get_file: ../../common/templates/kubernetes/fragments/write-kube-os-config.sh
             - get_file: ../../common/templates/kubernetes/fragments/make-cert-client.sh
             - get_file: ../../common/templates/fragments/configure-docker-registry.sh
             - get_file: ../../common/templates/kubernetes/fragments/configure-kubernetes-minion.sh

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -168,6 +168,10 @@ parameters:
     type: string
     description: ID of the security group for kubernetes minion.
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -552,6 +556,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_minion_floating:
     type: Magnum::Optional::KubeMinion::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/user_data.json
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/user_data.json
@@ -67,6 +67,21 @@
         "group": {
           "name": "root"
         },
+        "path": "/etc/containers/__REGISTRIES_CONF__",
+        "user": {
+          "name": "root"
+        },
+        "append": [
+          {
+            "source": "data:,%5B%5Bregistry%5D%5D%0Alocation%20%3D%20%22__INSECURE_REGISTRY_URL__%22%0Ainsecure%20%3D%20true%0A"
+          }
+        ],
+        "mode": 420
+      },
+      {
+        "group": {
+          "name": "root"
+        },
         "overwrite": true,
         "path": "/etc/hostname",
         "user": {

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/user_data.json
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/user_data.json
@@ -1,15 +1,5 @@
 {
   "ignition": {
-    "config": {
-      "replace": {
-        "source": null,
-        "verification": {}
-      }
-    },
-    "security": {
-      "tls": {}
-    },
-    "timeouts": {},
     "version": "3.0.0"
   },
   "passwd": {
@@ -56,8 +46,7 @@
           "name": "root"
         },
         "contents": {
-          "source": "data:,%23%20This%20file%20controls%20the%20state%20of%20SELinux%20on%20the%20system.%0A%23%20SELINUX%3D%20can%20take%20one%20of%20these%20three%20values%3A%0A%23%20%20%20%20%20enforcing%20-%20SELinux%20security%20policy%20is%20enforced.%0A%23%20%20%20%20%20permissive%20-%20SELinux%20prints%20warnings%20instead%20of%20enforcing.%0A%23%20%20%20%20%20disabled%20-%20No%20SELinux%20policy%20is%20loaded.%0ASELINUX%3D__SELINUX_MODE__%0A%23%20SELINUXTYPE%3D%20can%20take%20one%20of%20these%20three%20values%3A%0A%23%20%20%20%20%20targeted%20-%20Targeted%20processes%20are%20protected%2C%0A%23%20%20%20%20%20minimum%20-%20Modification%20of%20targeted%20policy.%20Only%20selected%20processes%20are%20protected.%0A%23%20%20%20%20%20mls%20-%20Multi%20Level%20Security%20protection.%0ASELINUXTYPE%3Dtargeted%0A",
-          "verification": {}
+          "source": "data:,%23%20This%20file%20controls%20the%20state%20of%20SELinux%20on%20the%20system.%0A%23%20SELINUX%3D%20can%20take%20one%20of%20these%20three%20values%3A%0A%23%20%20%20%20%20enforcing%20-%20SELinux%20security%20policy%20is%20enforced.%0A%23%20%20%20%20%20permissive%20-%20SELinux%20prints%20warnings%20instead%20of%20enforcing.%0A%23%20%20%20%20%20disabled%20-%20No%20SELinux%20policy%20is%20loaded.%0ASELINUX%3D__SELINUX_MODE__%0A%23%20SELINUXTYPE%3D%20can%20take%20one%20of%20these%20three%20values%3A%0A%23%20%20%20%20%20targeted%20-%20Targeted%20processes%20are%20protected%2C%0A%23%20%20%20%20%20minimum%20-%20Modification%20of%20targeted%20policy.%20Only%20selected%20processes%20are%20protected.%0A%23%20%20%20%20%20mls%20-%20Multi%20Level%20Security%20protection.%0ASELINUXTYPE%3Dtargeted%0A"
         },
         "mode": 420
       },
@@ -70,8 +59,7 @@
           "name": "root"
         },
         "contents": {
-          "source": "data:,%23%20Maximum%20size%20of%20log%20files%20(in%20bytes)%0A%23%20-1%20is%20unlimited%0A%23%2050m%0Amax_log_size%20%3D%2052428800%0A",
-          "verification": {}
+          "source": "data:,%23%20Maximum%20size%20of%20log%20files%20(in%20bytes)%0A%23%20-1%20is%20unlimited%0A%23%2050m%0Amax_log_size%20%3D%2052428800%0A"
         },
         "mode": 420
       },
@@ -85,8 +73,7 @@
           "name": "root"
         },
         "contents": {
-          "source": "data:,__HOSTNAME__%0A",
-          "verification": {}
+          "source": "data:,__HOSTNAME__%0A"
         },
         "mode": 420
       },
@@ -99,8 +86,7 @@
           "name": "root"
         },
         "contents": {
-          "source": "data:,__OPENSTACK_CA__%0A",
-          "verification": {}
+          "source": "data:,__OPENSTACK_CA__%0A"
         },
         "mode": 420
       },
@@ -113,8 +99,7 @@
           "name": "root"
         },
         "contents": {
-          "source": "data:,%23!%2Fbin%2Fbash%0A%0Aset%20-x%0Aset%20-e%0Aset%20%2Bu%0A%0Auntil%20%5B%20-f%20%2Fetc%2Fpki%2Fca-trust%2Fsource%2Fanchors%2Fopenstack-ca.pem%20%5D%0Ado%0A%20%20%20%20echo%20%22waiting%20for%20%2Fetc%2Fpki%2Fca-trust%2Fsource%2Fanchors%2Fopenstack-ca.pem%22%0A%20%20%20%20sleep%203s%0Adone%0A%0A%2Fusr%2Fbin%2Fupdate-ca-trust%0A%0AHTTP_PROXY%3D%22__HTTP_PROXY__%22%0AHTTPS_PROXY%3D%22__HTTPS_PROXY__%22%0ANO_PROXY%3D%22__NO_PROXY__%22%0A%0Aif%20%5B%20-n%20%22%24%7BHTTP_PROXY%7D%22%20%5D%3B%20then%0A%20%20%20%20export%20HTTP_PROXY%0A%20%20%20%20echo%20%22http_proxy%3D%24%7BHTTP_PROXY%7D%22%20%3E%3E%20%2Fetc%2Fenvironment%0Afi%0A%0Aif%20%5B%20-n%20%22%24%7BHTTPS_PROXY%7D%22%20%5D%3B%20then%0A%20%20%20%20export%20HTTPS_PROXY%0A%20%20%20%20echo%20%22https_proxy%3D%24%7BHTTPS_PROXY%7D%22%20%3E%3E%20%2Fetc%2Fenvironment%0Afi%0A%0Aif%20%5B%20-n%20%22%24%7BNO_PROXY%7D%22%20%5D%3B%20then%0A%20%20%20%20export%20NO_PROXY%0A%20%20%20%20echo%20%22no_proxy%3D%24%7BNO_PROXY%7D%22%20%3E%3E%20%2Fetc%2Fenvironment%0Afi%0A%0A%23%20Create%20a%20keypair%20for%20the%20heat-container-agent%20to%0A%23%20access%20the%20node%20over%20ssh.%20It%20is%20useful%20to%20operate%0A%23%20in%20host%20mount%20namespace%20and%20apply%20configuration.%0Aid%0Amkdir%20-p%20%2Fsrv%2Fmagnum%2F.ssh%0Achmod%200700%20%2Fsrv%2Fmagnum%2F.ssh%0A%23touch%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0Assh-keygen%20-q%20-t%20rsa%20-N%20''%20-f%20%2Ftmp%2Fheat_agent_rsa%0Amv%20%2Ftmp%2Fheat_agent_rsa%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0Amv%20%2Ftmp%2Fheat_agent_rsa.pub%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa.pub%0Achmod%200400%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0Achmod%200400%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa.pub%0A%23%20Add%20the%20public%20to%20the%20host%20authorized_keys%20file.%0Amkdir%20-p%20%2Froot%2F.ssh%0Achmod%200700%20%2Froot%2F.ssh%0Acat%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa.pub%20%3E%20%2Froot%2F.ssh%2Fauthorized_keys%0A%23%20Add%20localost%20to%20know_hosts%0Assh-keyscan%20127.0.0.1%20%3E%20%2Fsrv%2Fmagnum%2F.ssh%2Fknown_hosts%0A%23%20ssh%20configguration%20file%2C%20to%20be%20specified%20with%20ssh%20-F%0Acat%20%3E%20%2Fsrv%2Fmagnum%2F.ssh%2Fconfig%20%3C%3CEOF%0AHost%20localhost%0A%20%20%20%20%20HostName%20127.0.0.1%0A%20%20%20%20%20User%20root%0A%20%20%20%20%20IdentityFile%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0A%20%20%20%20%20UserKnownHostsFile%20%2Fsrv%2Fmagnum%2F.ssh%2Fknown_hosts%0AEOF%0A%0Ased%20-i%20'%2F%5EPermitRootLogin%2F%20s%2F%20.*%2F%20without-password%2F'%20%2Fetc%2Fssh%2Fsshd_config%0A%23%20Security%20enhancement%3A%20Disable%20password%20authentication%0Ased%20-i%20'%2F%5EPasswordAuthentication%20yes%2F%20s%2F%20yes%2F%20no%2F'%20%2Fetc%2Fssh%2Fsshd_config%0A%0Asystemctl%20restart%20sshd%0A",
-          "verification": {}
+          "source": "data:,%23!%2Fbin%2Fbash%0A%0Aset%20-x%0Aset%20-e%0Aset%20%2Bu%0A%0Auntil%20%5B%20-f%20%2Fetc%2Fpki%2Fca-trust%2Fsource%2Fanchors%2Fopenstack-ca.pem%20%5D%0Ado%0A%20%20%20%20echo%20%22waiting%20for%20%2Fetc%2Fpki%2Fca-trust%2Fsource%2Fanchors%2Fopenstack-ca.pem%22%0A%20%20%20%20sleep%203s%0Adone%0A%0A%2Fusr%2Fbin%2Fupdate-ca-trust%0Amkdir%20%2Fetc%2Fkubernetes%2F%0Acp%20%2Fetc%2Fpki%2Ftls%2Fcerts%2Fca-bundle.crt%20%2Fetc%2Fkubernetes%2Fca-bundle.crt%0A%0AHTTP_PROXY%3D%22__HTTP_PROXY__%22%0AHTTPS_PROXY%3D%22__HTTPS_PROXY__%22%0ANO_PROXY%3D%22__NO_PROXY__%22%0A%0Aif%20%5B%20-n%20%22%24%7BHTTP_PROXY%7D%22%20%5D%3B%20then%0A%20%20%20%20export%20HTTP_PROXY%0A%20%20%20%20echo%20%22http_proxy%3D%24%7BHTTP_PROXY%7D%22%20%3E%3E%20%2Fetc%2Fenvironment%0Afi%0A%0Aif%20%5B%20-n%20%22%24%7BHTTPS_PROXY%7D%22%20%5D%3B%20then%0A%20%20%20%20export%20HTTPS_PROXY%0A%20%20%20%20echo%20%22https_proxy%3D%24%7BHTTPS_PROXY%7D%22%20%3E%3E%20%2Fetc%2Fenvironment%0Afi%0A%0Aif%20%5B%20-n%20%22%24%7BNO_PROXY%7D%22%20%5D%3B%20then%0A%20%20%20%20export%20NO_PROXY%0A%20%20%20%20echo%20%22no_proxy%3D%24%7BNO_PROXY%7D%22%20%3E%3E%20%2Fetc%2Fenvironment%0Afi%0A%0A%23%20Create%20a%20keypair%20for%20the%20heat-container-agent%20to%0A%23%20access%20the%20node%20over%20ssh.%20It%20is%20useful%20to%20operate%0A%23%20in%20host%20mount%20namespace%20and%20apply%20configuration.%0Aid%0Amkdir%20-p%20%2Fsrv%2Fmagnum%2F.ssh%0Achmod%200700%20%2Fsrv%2Fmagnum%2F.ssh%0A%23touch%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0Assh-keygen%20-q%20-t%20rsa%20-N%20''%20-f%20%2Ftmp%2Fheat_agent_rsa%0Amv%20%2Ftmp%2Fheat_agent_rsa%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0Amv%20%2Ftmp%2Fheat_agent_rsa.pub%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa.pub%0Achmod%200400%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0Achmod%200400%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa.pub%0A%23%20Add%20the%20public%20to%20the%20host%20authorized_keys%20file.%0Amkdir%20-p%20%2Froot%2F.ssh%0Achmod%200700%20%2Froot%2F.ssh%0Acat%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa.pub%20%3E%20%2Froot%2F.ssh%2Fauthorized_keys%0A%23%20Add%20localost%20to%20know_hosts%0Assh-keyscan%20127.0.0.1%20%3E%20%2Fsrv%2Fmagnum%2F.ssh%2Fknown_hosts%0A%23%20ssh%20configguration%20file%2C%20to%20be%20specified%20with%20ssh%20-F%0Acat%20%3E%20%2Fsrv%2Fmagnum%2F.ssh%2Fconfig%20%3C%3CEOF%0AHost%20localhost%0A%20%20%20%20%20HostName%20127.0.0.1%0A%20%20%20%20%20User%20root%0A%20%20%20%20%20IdentityFile%20%2Fsrv%2Fmagnum%2F.ssh%2Fheat_agent_rsa%0A%20%20%20%20%20UserKnownHostsFile%20%2Fsrv%2Fmagnum%2F.ssh%2Fknown_hosts%0AEOF%0A%0Ased%20-i%20'%2F%5EPermitRootLogin%2F%20s%2F%20.*%2F%20without-password%2F'%20%2Fetc%2Fssh%2Fsshd_config%0A%23%20Security%20enhancement%3A%20Disable%20password%20authentication%0Ased%20-i%20'%2F%5EPasswordAuthentication%20yes%2F%20s%2F%20yes%2F%20no%2F'%20%2Fetc%2Fssh%2Fsshd_config%0A%0Asystemctl%20restart%20sshd%0A"
         },
         "mode": 448
       },
@@ -127,8 +112,7 @@
           "name": "root"
         },
         "contents": {
-          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A",
-          "verification": {}
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
         },
         "mode": 420
       }

--- a/magnum/tests/unit/api/controllers/v1/test_bay.py
+++ b/magnum/tests/unit/api/controllers/v1/test_bay.py
@@ -802,7 +802,7 @@ class TestPost(api_base.FunctionalTest):
         cluster_template = obj_utils.create_test_cluster_template(
             self.context, name='foo', uuid='foo', master_lb_enabled=False)
         bdict = apiutils.bay_post_data(baymodel_id=cluster_template.name,
-                                       master_count=3)
+                                       master_count=3, master_lb_enabled=False)
         response = self.post_json('/bays', bdict, expect_errors=True)
         self.assertEqual('application/json', response.content_type)
         self.assertEqual(400, response.status_int)

--- a/magnum/tests/unit/api/controllers/v1/test_cluster.py
+++ b/magnum/tests/unit/api/controllers/v1/test_cluster.py
@@ -845,7 +845,8 @@ class TestPost(api_base.FunctionalTest):
         cluster_template = obj_utils.create_test_cluster_template(
             self.context, name='foo', uuid='foo', master_lb_enabled=False)
         bdict = apiutils.cluster_post_data(
-            cluster_template_id=cluster_template.name, master_count=3)
+            cluster_template_id=cluster_template.name, master_count=3,
+            master_lb_enabled=False)
         response = self.post_json('/clusters', bdict, expect_errors=True)
         self.assertEqual('application/json', response.content_type)
         self.assertEqual(400, response.status_int)

--- a/magnum/tests/unit/api/controllers/v1/test_cluster.py
+++ b/magnum/tests/unit/api/controllers/v1/test_cluster.py
@@ -57,7 +57,8 @@ class TestClusterObject(base.TestCase):
 
 class TestListCluster(api_base.FunctionalTest):
     _cluster_attrs = ("name", "cluster_template_id", "node_count", "status",
-                      "master_count", "stack_id", "create_timeout")
+                      "project_id", "master_count", "stack_id",
+                      "create_timeout")
 
     _expand_cluster_attrs = ("name", "cluster_template_id", "node_count",
                              "status", "api_address", "discovery_url",

--- a/magnum/tests/unit/common/test_rpc.py
+++ b/magnum/tests/unit/common/test_rpc.py
@@ -42,38 +42,16 @@ class TestRpc(base.TestCase):
         self.assertEqual('client', client)
 
     @mock.patch.object(rpc, 'profiler', None)
-    @mock.patch.object(rpc, 'RequestContextSerializer')
     @mock.patch.object(messaging, 'get_rpc_server')
-    def test_get_server(self, mock_get, mock_ser):
+    def test_get_server(self, mock_get):
         rpc.TRANSPORT = mock.Mock()
         ser = mock.Mock()
         tgt = mock.Mock()
         ends = mock.Mock()
-        mock_ser.return_value = ser
         mock_get.return_value = 'server'
         access_policy = dispatcher.DefaultRPCAccessPolicy
-        server = rpc.get_server(tgt, ends, serializer='foo')
+        server = rpc.get_server(tgt, ends, serializer=ser)
 
-        mock_ser.assert_called_once_with('foo')
-        mock_get.assert_called_once_with(rpc.TRANSPORT, tgt, ends,
-                                         executor='eventlet', serializer=ser,
-                                         access_policy=access_policy)
-        self.assertEqual('server', server)
-
-    @mock.patch.object(rpc, 'profiler', mock.Mock())
-    @mock.patch.object(rpc, 'ProfilerRequestContextSerializer')
-    @mock.patch.object(messaging, 'get_rpc_server')
-    def test_get_server_profiler_enabled(self, mock_get, mock_ser):
-        rpc.TRANSPORT = mock.Mock()
-        ser = mock.Mock()
-        tgt = mock.Mock()
-        ends = mock.Mock()
-        mock_ser.return_value = ser
-        mock_get.return_value = 'server'
-        access_policy = dispatcher.DefaultRPCAccessPolicy
-        server = rpc.get_server(tgt, ends, serializer='foo')
-
-        mock_ser.assert_called_once_with('foo')
         mock_get.assert_called_once_with(rpc.TRANSPORT, tgt, ends,
                                          executor='eventlet', serializer=ser,
                                          access_policy=access_policy)

--- a/magnum/tests/unit/common/test_rpc.py
+++ b/magnum/tests/unit/common/test_rpc.py
@@ -26,38 +26,16 @@ from magnum.tests import base
 
 class TestRpc(base.TestCase):
     @mock.patch.object(rpc, 'profiler', None)
-    @mock.patch.object(rpc, 'RequestContextSerializer')
     @mock.patch.object(messaging, 'RPCClient')
-    def test_get_client(self, mock_client, mock_ser):
+    def test_get_client(self, mock_client):
         rpc.TRANSPORT = mock.Mock()
         tgt = mock.Mock()
         ser = mock.Mock()
         mock_client.return_value = 'client'
-        mock_ser.return_value = ser
 
-        client = rpc.get_client(tgt, version_cap='1.0', serializer='foo',
+        client = rpc.get_client(tgt, version_cap='1.0', serializer=ser,
                                 timeout=6969)
 
-        mock_ser.assert_called_once_with('foo')
-        mock_client.assert_called_once_with(rpc.TRANSPORT,
-                                            tgt, version_cap='1.0',
-                                            serializer=ser, timeout=6969)
-        self.assertEqual('client', client)
-
-    @mock.patch.object(rpc, 'profiler', mock.Mock())
-    @mock.patch.object(rpc, 'ProfilerRequestContextSerializer')
-    @mock.patch.object(messaging, 'RPCClient')
-    def test_get_client_profiler_enabled(self, mock_client, mock_ser):
-        rpc.TRANSPORT = mock.Mock()
-        tgt = mock.Mock()
-        ser = mock.Mock()
-        mock_client.return_value = 'client'
-        mock_ser.return_value = ser
-
-        client = rpc.get_client(tgt, version_cap='1.0', serializer='foo',
-                                timeout=6969)
-
-        mock_ser.assert_called_once_with('foo')
         mock_client.assert_called_once_with(rpc.TRANSPORT,
                                             tgt, version_cap='1.0',
                                             serializer=ser, timeout=6969)

--- a/magnum/tests/unit/db/utils.py
+++ b/magnum/tests/unit/db/utils.py
@@ -101,7 +101,7 @@ def get_test_cluster(**kw):
         'fixed_network': kw.get('fixed_network', None),
         'fixed_subnet': kw.get('fixed_subnet', None),
         'floating_ip_enabled': kw.get('floating_ip_enabled', True),
-        'master_lb_enabled': kw.get('master_lb_enabled', False),
+        'master_lb_enabled': kw.get('master_lb_enabled', True),
     }
 
     if kw.pop('for_api_use', False):

--- a/magnum/tests/unit/drivers/test_template_definition.py
+++ b/magnum/tests/unit/drivers/test_template_definition.py
@@ -607,6 +607,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
         metrics_scraper_tag = mock_cluster.labels.get('metrics_scraper_tag')
         master_lb_allowed_cidrs = mock_cluster.labels.get(
             'master_lb_allowed_cidrs')
+        vnic_type = mock_cluster.labels.get('vnic_type')
+        master_vnic_type = mock_cluster.labels.get('master_vnic_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -723,6 +725,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'metrics_scraper_tag': metrics_scraper_tag,
             'master_lb_allowed_cidrs': master_lb_allowed_cidrs,
             'fixed_subnet_cidr': '20.200.0.0/16',
+            'vnic_type': vnic_type,
+            'master_vnic_type': master_vnic_type,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,
@@ -1136,9 +1140,10 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'containerd_tarball_sha256')
         kube_image_digest = mock_cluster.labels.get('kube_image_digest')
         metrics_scraper_tag = mock_cluster.labels.get('metrics_scraper_tag')
-
         master_lb_allowed_cidrs = mock_cluster.labels.get(
             'master_lb_allowed_cidrs')
+        vnic_type = mock_cluster.labels.get('vnic_type')
+        master_vnic_type = mock_cluster.labels.get('master_vnic_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -1257,6 +1262,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'metrics_scraper_tag': metrics_scraper_tag,
             'master_lb_allowed_cidrs': master_lb_allowed_cidrs,
             'fixed_subnet_cidr': '20.200.0.0/16',
+            'vnic_type': vnic_type,
+            'master_vnic_type': master_vnic_type,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,

--- a/releasenotes/notes/default-admission-controller-04398548cf63597c.yaml
+++ b/releasenotes/notes/default-admission-controller-04398548cf63597c.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Now the default admission controller list is updated by as
+    "NodeRestriction, PodSecurityPolicy, NamespaceLifecycle, LimitRanger, ServiceAccount, ResourceQuota, TaintNodesByCondition, Priority, DefaultTolerationSeconds, DefaultStorageClass, StorageObjectInUseProtection, PersistentVolumeClaimResize, MutatingAdmissionWebhook, ValidatingAdmissionWebhook, RuntimeClass" 

--- a/releasenotes/notes/migrations-1.3.20-60e5f990422f2ca5.yaml
+++ b/releasenotes/notes/migrations-1.3.20-60e5f990422f2ca5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes database migrations with SQLAlchemy 1.3.20.

--- a/releasenotes/notes/update-containerd-version-url-c095c0ee3c1a538b.yaml
+++ b/releasenotes/notes/update-containerd-version-url-c095c0ee3c1a538b.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The default containerd version is updated with 1.4.3.

--- a/releasenotes/notes/vnic-type-ab55eee505bee5e5.yaml
+++ b/releasenotes/notes/vnic-type-ab55eee505bee5e5.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add support for `vnic_type` and `master_vnic_type` labels to make this
+    configurable beyond the current support for `normal` mode. This extends
+    support to other types of ports (e.g. SR-IOV ports).


### PR DESCRIPTION
Also picking the following merged commits from master:

```
672b119 Re-use transport for rpc server
1b72456 k8s: Do not use insecure api port
987c9d8 Re-use transport for rpc calls
7bfd751 [k8s-fcos] Fix insecure registry
8018bf9 Fix cluster deletion when load balancers don't exist
d11f4e8 Make kubelet and kube-proxy use the secure port
acc7084 Fix validation for master_lb_enabled
8bdf0e7 Update containerd version and tarball URL
fade245 [k8s] Fix default admission controller
333331b Update helm charts origin repository
327c12f Add image prefix for grafana images
34f6558 Use kube_master_ip for monitoring when no floating ip is used
56583ac Fix Cinder CSI
2c93427 k8s-fcos: Source bashrc for clusterconfig
9adfc44 Fix misquoted comment
f5cf6b9 Fix database migrations
a837b5c Update default k8s admission controller list
662b831 Drop KUBE_API_PORT for kube-apiserver
c84653c Remove cloud-config from k8s worker node
f3e88dd Fix syntax error in default rolesync configmap
2c63aca Stop using delete_on_termination for BFV instances
0e964f8 Remove duplicated etcd_volume_size param in coreos template
31623a1 Configure placeholder role-mapping Sync
799563e Remove shebang from scripts
9513b91 Remove warning for scale_manager
3e7924f Deploy traefik from the heat-agent
```

Additionally the following unmerged commits:
```
773886            master  Loadbalancer pre-deletion should not be fatal
774497            master  Return project_id when listing clusters
753312            master  [fix] Detect virtio-scsi volumes correctly
748458            master  [k8s] Add vnic_type label to support SR-IOV ports
```