### PR TITLE
Extra features for our fork required by customers

### DIFF
--- a/api-ref/source/clusters.inc
+++ b/api-ref/source/clusters.inc
@@ -105,6 +105,7 @@ Response
   - cluster_template_id: clustertemplate_id
   - node_count: node_count
   - create_timeout: create_timeout
+  - project_id: project_id
   - name: name
 
 Response Example
@@ -163,6 +164,7 @@ Response
   - node_addresses: node_addresses
   - status_reason: status_reason
   - create_timeout: create_timeout
+  - project_id: project_id
   - name: name
 
 Response Example

--- a/api-ref/source/clustertemplates.inc
+++ b/api-ref/source/clustertemplates.inc
@@ -48,6 +48,7 @@ Request
   - volume_driver: volume_driver
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
+  - project_id: project_id
   - name: name
   - network_driver: network_driver
   - fixed_network: fixed_network
@@ -93,6 +94,7 @@ Response
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
   - apiserver_port: apiserver_port
+  - project_id: project_id
   - name: name
   - created_at: created_at
   - network_driver: network_driver
@@ -158,6 +160,7 @@ Response
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
   - apiserver_port: apiserver_port
+  - project_id: project_id
   - name: name
   - created_at: created_at
   - network_driver: network_driver
@@ -231,6 +234,7 @@ Response
   - registry_enabled: registry_enabled
   - docker_storage_driver: docker_storage_driver
   - apiserver_port: apiserver_port
+  - project_id: project_id
   - name: name
   - created_at: created_at
   - network_driver: network_driver

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -485,6 +485,11 @@ the table are linked to more details elsewhere in the user guide.
 +---------------------------------------+--------------------+---------------+
 | `fixed_subnet_cidr`_                  | see below          | ""            |
 +---------------------------------------+--------------------+---------------+
+| `vnic_type`_                          | see below          | "normal"      |
++---------------------------------------+--------------------+---------------+
+| `master_vnic_type`_                   | see below          | "normal       |
++---------------------------------------+--------------------+---------------+
+
 
 .. _cluster:
 
@@ -1640,6 +1645,15 @@ _`fixed_subnet_cidr`
   CIDR of the fixed subnet created by Magnum when a user has not
   specified an existing fixed_subnet during cluster creation.
   Ussuri default: 10.0.0.0/24
+
+_`vnic_type`
+  The vnic type to use for ports attached to worker nodes. This allows
+  the user to, for example, attach SR-IOV ports to instances.
+  Default: normal
+
+_`master_vnic_type`
+  The vnic type to use for ports attached to worker nodes.
+  Default: normal
 
 External load balancer for services
 -----------------------------------

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -489,7 +489,10 @@ the table are linked to more details elsewhere in the user guide.
 +---------------------------------------+--------------------+---------------+
 | `master_vnic_type`_                   | see below          | "normal       |
 +---------------------------------------+--------------------+---------------+
-
+| `extra_network`_                      | see below          | ""            |
++---------------------------------------+--------------------+---------------+
+| `extra_subnet`_                       | see below          | ""            |
++---------------------------------------+--------------------+---------------+
 
 .. _cluster:
 
@@ -1655,6 +1658,12 @@ _`master_vnic_type`
   The vnic type to use for ports attached to worker nodes.
   Default: normal
 
+_`extra_network`
+  Optional additional network to add to cluster nodes.
+
+_`extra_subnet`
+  Optional additional subnet to add to cluster nodes.
+
 External load balancer for services
 -----------------------------------
 
@@ -2737,7 +2746,6 @@ _`calico_tag`
   Stein default: v2.6.7
   Train default: v3.3.6
   Ussuri default: v3.13.1
-
 
 Besides, the Calico network driver needs kube_tag with v1.9.3 or later, because
 Calico needs extra mounts for the kubelet container. See `commit

--- a/magnum/api/controllers/v1/cluster.py
+++ b/magnum/api/controllers/v1/cluster.py
@@ -228,6 +228,7 @@ class Cluster(base.APIBase):
                                          'labels', 'node_count', 'status',
                                          'master_flavor_id', 'flavor_id',
                                          'create_timeout', 'master_count',
+                                         'project_id',
                                          'stack_id', 'health_status'])
         else:
             overridden, added, skipped = api_utils.get_labels_diff(
@@ -255,6 +256,7 @@ class Cluster(base.APIBase):
         temp_id = '4a96ac4b-2447-43f1-8ca6-9fd6f36d146d'
         sample = cls(uuid='27e3153e-d5bf-4b7e-b517-fb518e17f34c',
                      name='example',
+                     project_id='37e3153e-d5bf-4b7e-b517-fb518e17f34d',
                      cluster_template_id=temp_id,
                      keypair=None,
                      node_count=2,

--- a/magnum/drivers/common/templates/fragments/configure-docker-storage.sh
+++ b/magnum/drivers/common/templates/fragments/configure-docker-storage.sh
@@ -13,7 +13,7 @@ if [ -n "$DOCKER_VOLUME_SIZE" ] && [ "$DOCKER_VOLUME_SIZE" -gt 0 ]; then
     else
         attempts=60
         while [ ${attempts} -gt 0 ]; do
-            device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${DOCKER_VOLUME:0:20}$)
+            device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${DOCKER_VOLUME:0:20} | head -n1)
             if [ -n "${device_name}" ]; then
                 break
             fi

--- a/magnum/drivers/common/templates/kubernetes/fragments/configure-etcd.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/configure-etcd.sh
@@ -20,7 +20,7 @@ if [ -n "$ETCD_VOLUME_SIZE" ] && [ "$ETCD_VOLUME_SIZE" -gt 0 ]; then
 
     attempts=60
     while [ ${attempts} -gt 0 ]; do
-        device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${ETCD_VOLUME:0:20}$)
+        device_name=$($ssh_cmd ls /dev/disk/by-id | grep ${ETCD_VOLUME:0:20} | head -n1)
         if [ -n "${device_name}" ]; then
             break
         fi

--- a/magnum/drivers/heat/driver.py
+++ b/magnum/drivers/heat/driver.py
@@ -304,7 +304,10 @@ class KubernetesDriver(HeatDriver):
         if keystone.is_octavia_enabled():
             LOG.info("Starting to delete loadbalancers for cluster %s",
                      cluster.uuid)
-            octavia.delete_loadbalancers(context, cluster)
+            try:
+                octavia.delete_loadbalancers(context, cluster)
+            except exception.PreDeletionFailed as e:
+                LOG.error(str(e))
 
     def upgrade_cluster(self, context, cluster, cluster_template,
                         max_batch_size, nodegroup, scale_manager=None,

--- a/magnum/drivers/heat/k8s_fedora_template_def.py
+++ b/magnum/drivers/heat/k8s_fedora_template_def.py
@@ -118,6 +118,7 @@ class K8sFedoraTemplateDefinition(k8s_template_def.K8sTemplateDefinition):
                       'min_node_count', 'max_node_count', 'npd_enabled',
                       'ostree_remote', 'ostree_commit',
                       'use_podman', 'kube_image_digest',
+                      'vnic_type', 'master_vnic_type',
                       'metrics_scraper_tag']
 
         labels = self._get_relevant_labels(cluster, kwargs)

--- a/magnum/drivers/heat/k8s_fedora_template_def.py
+++ b/magnum/drivers/heat/k8s_fedora_template_def.py
@@ -119,7 +119,8 @@ class K8sFedoraTemplateDefinition(k8s_template_def.K8sTemplateDefinition):
                       'ostree_remote', 'ostree_commit',
                       'use_podman', 'kube_image_digest',
                       'vnic_type', 'master_vnic_type',
-                      'metrics_scraper_tag']
+                      'metrics_scraper_tag',
+                      'extra_network', 'extra_subnet']
 
         labels = self._get_relevant_labels(cluster, kwargs)
 

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -925,6 +925,16 @@ parameters:
     description: The allowed CIDR list for master load balancer
     default: []
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to worker nodes
+    default: "normal"
+
+  master_vnic_type:
+    type: string
+    description: vnic type for ports attached to master nodes
+    default: "normal"
+
 resources:
 
   ######################################################################
@@ -1165,6 +1175,7 @@ resources:
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
           traefik_ingress_controller_tag: {get_param: traefik_ingress_controller_tag}
+          vnic_type: {get_param: master_vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           fixed_network: {get_attr: [network, fixed_network]}
@@ -1395,6 +1406,7 @@ resources:
           registry_chunksize: {get_param: registry_chunksize}
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
+          vnic_type: {get_param: vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           auth_url: {get_param: auth_url}

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubemaster.yaml
@@ -104,6 +104,10 @@ parameters:
       the docker cgroup driver.
     default: "cgroupfs"
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -923,6 +927,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_master_floating:
     type: Magnum::Optional::KubeMaster::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubeminion.yaml
@@ -164,6 +164,10 @@ parameters:
     type: string
     description: ID of the security group for kubernetes minion.
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -545,6 +549,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_minion_floating:
     type: Magnum::Optional::KubeMinion::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -42,6 +42,12 @@ conditions:
       data:
         calico_tag: {get_param: calico_tag}
 
+  extra_port:
+    not:
+      equals:
+      - get_param: extra_network
+      - ''
+
 parameters:
 
   # needs to become a list if we want to join master nodes?
@@ -953,6 +959,19 @@ parameters:
     description: vnic type for ports attached to master nodes
     default: "normal"
 
+  extra_network:
+    type: string
+    description: >
+      Additional network to bind nodes to
+    default: ''
+
+  extra_subnet:
+    type: string
+    description: >
+      Subnet for additional network
+    default: ''
+
+
 resources:
 
   ######################################################################
@@ -1308,6 +1327,8 @@ resources:
           containerd_tarball_sha256: {get_param: containerd_tarball_sha256}
           post_install_manifest_url: {get_param: post_install_manifest_url}
           metrics_scraper_tag: {get_param: metrics_scraper_tag}
+          extra_network: {get_param: extra_network}
+          extra_subnet: {get_param: extra_subnet}
 
   kube_cluster_config:
     condition: create_cluster_resources
@@ -1485,6 +1506,10 @@ resources:
           containerd_version: {get_param: containerd_version}
           containerd_tarball_url: {get_param: containerd_tarball_url}
           containerd_tarball_sha256: {get_param: containerd_tarball_sha256}
+          kube_service_account_key: {get_param: kube_service_account_key}
+          kube_service_account_private_key: {get_param: kube_service_account_private_key}
+          extra_network: {get_param: extra_network}
+          extra_subnet: {get_param: extra_subnet}
 
 outputs:
 

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -943,6 +943,16 @@ parameters:
     description: The allowed CIDR list for master load balancer
     default: []
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to worker nodes
+    default: "normal"
+
+  master_vnic_type:
+    type: string
+    description: vnic type for ports attached to master nodes
+    default: "normal"
+
 resources:
 
   ######################################################################
@@ -1193,6 +1203,7 @@ resources:
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
           traefik_ingress_controller_tag: {get_param: traefik_ingress_controller_tag}
+          vnic_type: {get_param: master_vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           fixed_network: {get_attr: [network, fixed_network]}
@@ -1426,6 +1437,7 @@ resources:
           registry_chunksize: {get_param: registry_chunksize}
           cluster_uuid: {get_param: cluster_uuid}
           magnum_url: {get_param: magnum_url}
+          vnic_type: {get_param: vnic_type}
           volume_driver: {get_param: volume_driver}
           region_name: {get_param: region_name}
           auth_url: {get_param: auth_url}

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -656,6 +656,16 @@ parameters:
     description: >
       Tag of metrics-scraper for kubernetes dashboard.
 
+  extra_network:
+    type: string
+    description: >
+      Additional network name to bind ports to instances
+
+  extra_subnet:
+    type: string
+    description: >
+      Additional subnet name
+
 conditions:
 
   image_based: {equals: [{get_param: boot_volume_size}, 0]}
@@ -664,6 +674,12 @@ conditions:
       equals:
       - get_param: boot_volume_size
       - 0
+
+  extra_port:
+    not:
+      equals:
+      - get_param: extra_network
+      - ''
 
 resources:
   ######################################################################
@@ -913,7 +929,12 @@ resources:
       software_config_transport: POLL_SERVER_HEAT
       user_data: {get_resource: agent_config}
       networks:
-        - port: {get_resource: kube_master_eth0}
+        list_concat:
+          - - port: {get_resource: kube_master_eth0}
+          - if:
+              - "extra_port"
+              - - port: {get_resource: kube_master_eth1}
+              - []
       scheduler_hints: { group: { get_param: nodes_server_group_id }}
       availability_zone: {get_param: availability_zone}
 
@@ -927,7 +948,12 @@ resources:
       software_config_transport: POLL_SERVER_HEAT
       user_data: {get_resource: agent_config}
       networks:
-        - port: {get_resource: kube_master_eth0}
+        list_concat:
+          - - port: {get_resource: kube_master_eth0}
+          - if:
+              - "extra_port"
+              - - port: {get_resource: kube_master_eth1}
+              - []
       scheduler_hints: { group: { get_param: nodes_server_group_id }}
       availability_zone: {get_param: availability_zone}
       block_device_mapping_v2:
@@ -946,6 +972,17 @@ resources:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
       binding:vnic_type: {get_param: vnic_type}
+
+  kube_master_eth1:
+    type: OS::Neutron::Port
+    condition: extra_port
+    properties:
+      network: {get_param: extra_network}
+      security_groups:
+        - {get_param: secgroup_kube_master_id}
+      fixed_ips:
+        - subnet: {get_param: extra_subnet}
+      replacement_policy: AUTO
 
   kube_master_floating:
     type: Magnum::Optional::KubeMaster::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubemaster.yaml
@@ -108,6 +108,10 @@ parameters:
       the docker cgroup driver.
     default: "cgroupfs"
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -941,6 +945,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_master_floating:
     type: Magnum::Optional::KubeMaster::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -354,6 +354,31 @@ parameters:
     type: string
     description: sha256 of the target containerd tarball.
 
+  kube_service_account_key:
+    type: string
+    hidden: true
+    description: >
+      The signed cert will be used to verify the k8s service account tokens
+      during authentication.
+      NOTE: This is used for worker nodes to trigger certs rotate.
+
+  kube_service_account_private_key:
+    type: string
+    hidden: true
+    description: >
+      The private key will be used to sign generated k8s service account
+      tokens.
+
+  extra_network:
+    type: string
+    description: >
+      Additional network name to bind ports to instances
+
+  extra_subnet:
+    type: string
+    description: >
+      Additional subnet name
+
 conditions:
 
   image_based: {equals: [{get_param: boot_volume_size}, 0]}
@@ -362,6 +387,12 @@ conditions:
       equals:
       - get_param: boot_volume_size
       - 0
+
+  extra_port:
+    not:
+      equals:
+      - get_param: extra_network
+      - ''
 
 resources:
 
@@ -524,7 +555,12 @@ resources:
       user_data_format: SOFTWARE_CONFIG
       software_config_transport: POLL_SERVER_HEAT
       networks:
-        - port: {get_resource: kube_minion_eth0}
+        list_concat:
+          - - port: {get_resource: kube_minion_eth0}
+          - if:
+              - "extra_port"
+              - - port: {get_resource: kube_minion_eth1}
+              - []
       scheduler_hints: { group: { get_param: nodes_server_group_id }}
       availability_zone: {get_param: availability_zone}
 
@@ -538,7 +574,12 @@ resources:
       user_data_format: SOFTWARE_CONFIG
       software_config_transport: POLL_SERVER_HEAT
       networks:
-        - port: {get_resource: kube_minion_eth0}
+        list_concat:
+          - - port: {get_resource: kube_minion_eth0}
+          - if:
+              - "extra_port"
+              - - port: {get_resource: kube_minion_eth1}
+              - []
       scheduler_hints: { group: { get_param: nodes_server_group_id }}
       availability_zone: {get_param: availability_zone}
       block_device_mapping_v2:
@@ -557,6 +598,17 @@ resources:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
       binding:vnic_type: {get_param: vnic_type}
+
+  kube_minion_eth1:
+    type: OS::Neutron::Port
+    condition: extra_port
+    properties:
+      network: {get_param: extra_network}
+      security_groups:
+        - get_param: secgroup_kube_minion_id
+      fixed_ips:
+        - subnet: {get_param: extra_subnet}
+      replacement_policy: AUTO
 
   kube_minion_floating:
     type: Magnum::Optional::KubeMinion::Neutron::FloatingIP

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -168,6 +168,10 @@ parameters:
     type: string
     description: ID of the security group for kubernetes minion.
 
+  vnic_type:
+    type: string
+    description: vnic type for ports attached to nodes
+
   volume_driver:
     type: string
     description: volume driver to use for container storage
@@ -552,6 +556,7 @@ resources:
       allowed_address_pairs:
         - ip_address: {get_param: pods_network_cidr}
       replacement_policy: AUTO
+      binding:vnic_type: {get_param: vnic_type}
 
   kube_minion_floating:
     type: Magnum::Optional::KubeMinion::Neutron::FloatingIP

--- a/magnum/tests/unit/api/controllers/v1/test_cluster.py
+++ b/magnum/tests/unit/api/controllers/v1/test_cluster.py
@@ -57,7 +57,8 @@ class TestClusterObject(base.TestCase):
 
 class TestListCluster(api_base.FunctionalTest):
     _cluster_attrs = ("name", "cluster_template_id", "node_count", "status",
-                      "master_count", "stack_id", "create_timeout")
+                      "project_id", "master_count", "stack_id",
+                      "create_timeout")
 
     _expand_cluster_attrs = ("name", "cluster_template_id", "node_count",
                              "status", "api_address", "discovery_url",

--- a/magnum/tests/unit/drivers/test_template_definition.py
+++ b/magnum/tests/unit/drivers/test_template_definition.py
@@ -607,6 +607,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
         metrics_scraper_tag = mock_cluster.labels.get('metrics_scraper_tag')
         master_lb_allowed_cidrs = mock_cluster.labels.get(
             'master_lb_allowed_cidrs')
+        vnic_type = mock_cluster.labels.get('vnic_type')
+        master_vnic_type = mock_cluster.labels.get('master_vnic_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -723,6 +725,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'metrics_scraper_tag': metrics_scraper_tag,
             'master_lb_allowed_cidrs': master_lb_allowed_cidrs,
             'fixed_subnet_cidr': '20.200.0.0/16',
+            'vnic_type': vnic_type,
+            'master_vnic_type': master_vnic_type,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,
@@ -1136,9 +1140,10 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'containerd_tarball_sha256')
         kube_image_digest = mock_cluster.labels.get('kube_image_digest')
         metrics_scraper_tag = mock_cluster.labels.get('metrics_scraper_tag')
-
         master_lb_allowed_cidrs = mock_cluster.labels.get(
             'master_lb_allowed_cidrs')
+        vnic_type = mock_cluster.labels.get('vnic_type')
+        master_vnic_type = mock_cluster.labels.get('master_vnic_type')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -1257,6 +1262,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'metrics_scraper_tag': metrics_scraper_tag,
             'master_lb_allowed_cidrs': master_lb_allowed_cidrs,
             'fixed_subnet_cidr': '20.200.0.0/16',
+            'vnic_type': vnic_type,
+            'master_vnic_type': master_vnic_type,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,

--- a/magnum/tests/unit/drivers/test_template_definition.py
+++ b/magnum/tests/unit/drivers/test_template_definition.py
@@ -609,6 +609,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'master_lb_allowed_cidrs')
         vnic_type = mock_cluster.labels.get('vnic_type')
         master_vnic_type = mock_cluster.labels.get('master_vnic_type')
+        extra_network = mock_cluster.labels.get('extra_network')
+        extra_subnet = mock_cluster.labels.get('extra_subnet')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -727,6 +729,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'fixed_subnet_cidr': '20.200.0.0/16',
             'vnic_type': vnic_type,
             'master_vnic_type': master_vnic_type,
+            'extra_network': extra_network,
+            'extra_subnet': extra_subnet,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,
@@ -1144,6 +1148,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'master_lb_allowed_cidrs')
         vnic_type = mock_cluster.labels.get('vnic_type')
         master_vnic_type = mock_cluster.labels.get('master_vnic_type')
+        extra_network = mock_cluster.labels.get('extra_network')
+        extra_subnet = mock_cluster.labels.get('extra_subnet')
 
         k8s_def = k8sa_tdef.AtomicK8sTemplateDefinition()
 
@@ -1264,6 +1270,8 @@ class AtomicK8sTemplateDefinitionTestCase(BaseK8sTemplateDefinitionTestCase):
             'fixed_subnet_cidr': '20.200.0.0/16',
             'vnic_type': vnic_type,
             'master_vnic_type': master_vnic_type,
+            'extra_network': extra_network,
+            'extra_subnet': extra_subnet,
         }}
         mock_get_params.assert_called_once_with(mock_context,
                                                 mock_cluster_template,

--- a/releasenotes/notes/extra-network-interface-68bc169cb467a13e.yaml
+++ b/releasenotes/notes/extra-network-interface-68bc169cb467a13e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Support extra_network and extra_subnet labels to allow users to assign
+    extra network interface to cluster nodes, e.g. storage network.

--- a/releasenotes/notes/vnic-type-ab55eee505bee5e5.yaml
+++ b/releasenotes/notes/vnic-type-ab55eee505bee5e5.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add support for `vnic_type` and `master_vnic_type` labels to make this
+    configurable beyond the current support for `normal` mode. This extends
+    support to other types of ports (e.g. SR-IOV ports).


### PR DESCRIPTION
This PR proposes adding the following features unmerged on master to our fork:
```
773886         master  Loadbalancer pre-deletion should not be fatal
774497         master  Return project_id when listing clusters
753312         master  [fix] Detect virtio-scsi volumes correctly
748458         master  [k8s] Add vnic_type label to support SR-IOV ports
775793         master  Support extra_network and extra_subnet labels
```