### PR TITLE
Update magnum k8s monitoring infra

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -1276,13 +1276,14 @@ _`container_infra_prefix`
 
   Images that might be needed if 'monitoring_enabled' is 'true':
 
-  * quay.io/prometheus/alertmanager:v0.20.0
-  * docker.io/squareup/ghostunnel:v1.5.2
-  * docker.io/jettech/kube-webhook-certgen:v1.0.0
-  * quay.io/coreos/prometheus-operator:v0.37.0
-  * quay.io/coreos/configmap-reload:v0.0.1
-  * quay.io/coreos/prometheus-config-reloader:v0.37.0
-  * quay.io/prometheus/prometheus:v2.15.2
+  * quay.io/prometheus/alertmanager:v0.21.0
+  * docker.io/jettech/kube-webhook-certgen:v1.5.0
+  * quay.io/prometheus-operator/prometheus-operator:v0.44.0
+  * docker.io/jimmidyson/configmap-reload:v0.4.0
+  * quay.io/prometheus-operator/prometheus-config-reloader:v0.44.0
+  * quay.io/prometheus/prometheus:v2.22.1
+  * quay.io/prometheus/node-exporter:v1.0.1
+  * docker.io/directxman12/k8s-prometheus-adapter:v0.8.2
 
   Images that might be needed if 'cinder_csi_enabled' is 'true':
 

--- a/doc/source/user/monitoring.rst
+++ b/doc/source/user/monitoring.rst
@@ -35,15 +35,15 @@ _`metrics_server_enabled`
 
 _`monitoring_enabled`
   Enable installation of cluster monitoring solution provided by the
-  stable/prometheus-operator helm chart.
+  prometheus-community/kube-prometheus-stack helm chart.
   To use this service tiller_enabled must be true when using
   helm_client_tag<v3.0.0.
   Default: false
 
 _`prometheus_adapter_enabled`
   Enable installation of cluster custom metrics provided by the
-  stable/prometheus-adapter helm chart. This service depends on
-  monitoring_enabled.
+  prometheus-community/prometheus-adapter helm chart.
+  This service depends on monitoring_enabled.
   Default: true
 
 To control deployed versions, extra labels are available:
@@ -56,14 +56,17 @@ _`metrics_server_chart_tag`
 
 _`prometheus_operator_chart_tag`
   Add prometheus_operator_chart_tag to select version of the
-  stable/prometheus-operator chart to install. When installing the chart,
-  helm will use the default values of the tag defined and overwrite them based
-  on the prometheus-operator-config ConfigMap currently defined. You must
-  certify that the versions are compatible.
+  prometheus-community/kube-prometheus-stack chart to install.
+  When installing the chart, helm will use the default values of the tag
+  defined and overwrite them based on the prometheus-operator-config
+  ConfigMap currently defined.
+  You must certify that the versions are compatible.
+  Wallaby-default: 17.2.0
 
 _`prometheus_adapter_chart_tag`
-  The stable/prometheus-adapter helm chart version to use.
+  The prometheus-community/prometheus-adapter helm chart version to use.
   Train-default: 1.4.0
+  Wallaby-default: 2.12.1
 
 Full fledged cluster monitoring
 +++++++++++++++++++++++++++++++

--- a/magnum/drivers/common/templates/kubernetes/helm/prometheus-adapter.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/prometheus-adapter.sh
@@ -21,10 +21,11 @@ EOF
     cat << EOF >> ${HELM_CHART_DIR}/values.yaml
 prometheus-adapter:
   image:
-    repository: ${CONTAINER_INFRA_PREFIX:-docker.io/directxman12/}k8s-prometheus-adapter-${ARCH}
+    repository: ${CONTAINER_INFRA_PREFIX:-k8s.gcr.io/prometheus-adapter/}prometheus-adapter
   priorityClassName: "system-cluster-critical"
   prometheus:
-    url: http://web.tcp.prometheus-prometheus.kube-system.svc.cluster.local
+    url: http://web.tcp.magnum-kube-prometheus-sta-prometheus.kube-system.svc.cluster.local
+    path: /prometheus
   resources:
     requests:
       cpu: 150m

--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -740,8 +740,8 @@ parameters:
 
   prometheus_operator_chart_tag:
     type: string
-    description: The stable/prometheus-operator chart version to use.
-    default: v8.12.13
+    description: The prometheus-community/kube-prometheus-stack chart version to use.
+    default: 17.2.0
 
   prometheus_adapter_enabled:
     type: boolean
@@ -750,8 +750,8 @@ parameters:
 
   prometheus_adapter_chart_tag:
     type: string
-    description: The stable/prometheus-adapter chart version to use.
-    default: 1.4.0
+    description: The prometheus-community/prometheus-adapter chart version to use.
+    default: 2.5.1
 
   prometheus_adapter_configmap:
     type: string
@@ -1051,6 +1051,10 @@ resources:
         - protocol: udp
           port_range_min: 8472
           port_range_max: 8472
+          # Prometheus Server
+        - protocol: tcp
+          port_range_min: 9090
+          port_range_max: 9090
 
   secgroup_kube_minion:
     condition: create_cluster_resources

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -772,8 +772,8 @@ parameters:
 
   prometheus_operator_chart_tag:
     type: string
-    description: The stable/prometheus-operator chart version to use.
-    default: v8.12.13
+    description: The prometheus-community/kube-prometheus-stack chart version to use.
+    default: 33.0.0
 
   prometheus_adapter_enabled:
     type: boolean
@@ -782,8 +782,8 @@ parameters:
 
   prometheus_adapter_chart_tag:
     type: string
-    description: The stable/prometheus-adapter chart version to use.
-    default: 1.4.0
+    description: The prometheus-community/prometheus-adapter chart version to use.
+    default: 3.0.2
 
   prometheus_adapter_configmap:
     type: string
@@ -1125,6 +1125,10 @@ resources:
         - protocol: udp
           port_range_min: 8472
           port_range_max: 8472
+          # Prometheus Server
+        - protocol: tcp
+          port_range_min: 9090
+          port_range_max: 9090
 
   secgroup_kube_minion:
     condition: create_cluster_resources

--- a/releasenotes/notes/update-monitoring-charts-1067dc4a0f0060b6.yaml
+++ b/releasenotes/notes/update-monitoring-charts-1067dc4a0f0060b6.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - Prometheus-Adapter helm chart updated to 2.12.1 from 1.4.0.
+  - Prometheus-Operator helm chart updated to kube-prometheus-stack:17.2.0
+    from prometheus-operator:v8.12.13.
+  - Prometheus-server now runs only on master nodes
+
+deprecations:
+  - Enabling monitoring using the prometheus_monitoring label is deprecated
+    and will be removed in the X cycle.


### PR DESCRIPTION
* Prometheus-server now runs only on master nodes.
* Update prometheus-operator helm chart and tag.
* Update prometheus-adapter version.
* Deprecation notice for prometheus_monitoring component.

task: 41569
story: 2006765

Signed-off-by: Diogo Guerra <diogo.filipe.tomas.guerra@cern.ch>
Change-Id: I05e8c2be4e4c8e66a166b485ec7851875dca8b1c