### PR TITLE
Disable and stop docker when the CRI is containerd

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
@@ -8,7 +8,8 @@ set -x
 ssh_cmd="ssh -F /srv/magnum/.ssh/config root@localhost"
 
 if [ "${CONTAINER_RUNTIME}" = "containerd"  ] ; then
-    $ssh_cmd systemctl disable docker
+    $ssh_cmd systemctl disable docker.service docker.socket
+    $ssh_cmd systemctl stop docker.service docker.socket
     if [ -z "${CONTAINERD_TARBALL_URL}"  ] ; then
         CONTAINERD_TARBALL_URL="https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz"
     fi


### PR DESCRIPTION
Previously the docker service was disabled but kept running.
And if stopped, would be restarted by the docker socket.

Docker can be fully disabled and stopped when using containerd.

Change-Id: Ic3529106806f90dcafc24006c6c0dbc30e33766b