### PR TITLE
Containerd cni plugin path in CoreOS 35

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/install-cri.sh
@@ -8,7 +8,11 @@ set -x
 ssh_cmd="ssh -F /srv/magnum/.ssh/config root@localhost"
 
 if [ "${CONTAINER_RUNTIME}" = "containerd"  ] ; then
-    $ssh_cmd systemctl disable docker
+    $ssh_cmd systemctl disable docker.service docker.socket
+    $ssh_cmd systemctl stop docker.service docker.socket
+    if $ssh_cmd [ -f /etc/containerd/config.toml ] ; then
+        $ssh_cmd sed -i 's/bin_dir.*$/bin_dir\ =\ \""\/opt\/cni\/bin\/"\"/' /etc/containerd/config.toml
+    fi
     if [ -z "${CONTAINERD_TARBALL_URL}"  ] ; then
         CONTAINERD_TARBALL_URL="https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz"
     fi


### PR DESCRIPTION
Task: 45387
Story: 2010041

In Fedora CoreOS 35 default containerd cni bin_dir is set to
/usr/libexec/cni. Since we're installing our own in /opt/cni/bin need to
override in containerd config.toml otherwise pods get stuck in
ContainerCreating state looking for for ex. calico in wrong path.

Change-Id: I3242b718e32c92942ac471bc7e182a42e803005b