### PR TITLE
Removed appending to ca.crt

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/make-cert-client.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/make-cert-client.sh
@@ -77,7 +77,7 @@ EOF
     curl $VERIFY_CA -X GET \
         -H "X-Auth-Token: $USER_TOKEN" \
         -H "OpenStack-API-Version: container-infra latest" \
-        $MAGNUM_URL/certificates/$CLUSTER_UUID | python -c 'import sys, json; print(json.load(sys.stdin)["pem"])' >> $CA_CERT
+        $MAGNUM_URL/certificates/$CLUSTER_UUID | python -c 'import sys, json; print(json.load(sys.stdin)["pem"])' > $CA_CERT
 
     # Generate client's private key and csr
     $ssh_cmd openssl genrsa -out "${_KEY}" 4096


### PR DESCRIPTION
Appending to ca.crt in make-cert-client.sh (introduced in #724203) causes
multiple identical ca certs being added into /etc/kubernetes/certs/ca.crt which
prevents kube-controller-manager from starting with following error:

'expected 1 certificate, found X'

Task: 45392
Story: 2010042

Change-Id: I5ca9cb8c7afb1ce9cb1a337a9fe2faf3fab3ba61