### PR TITLE
Revert "Merge pull request #39 from stackhpc/fix_smt_on_fedora_coreos"

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -105,13 +105,13 @@ They are loosely grouped as: mandatory, infrastructure, COE specific.
   as appropriate for the cluster driver.  For the currently supported
   images, the os_distro names are:
 
-  ========== ==========================
+  ========== =====================
   COE        os_distro
-  ========== ==========================
-  Kubernetes fedora-coreos (minimum 34)
+  ========== =====================
+  Kubernetes fedora-coreos
   Swarm      fedora-atomic
   Mesos      ubuntu
-  ========== ==========================
+  ========== =====================
 
   This is a mandatory parameter and there is no default value. Note that the
   os_distro attribute is case sensitive.

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/fcct-config.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/fcct-config.yaml
@@ -12,12 +12,7 @@
 # [0] https://github.com/coreos/fcct
 # [1] https://github.com/coreos/fedora-coreos-docs/blob/master/modules/ROOT/pages/producing-ign.adoc
 variant: fcos
-version: 1.4.0
-kernel_arguments:
-  should_exist:
-    - mitigations=off
-  should_not_exist:
-    - mitigations=auto,nosmt
+version: 1.0.0
 passwd:
   users:
     - name: core
@@ -48,7 +43,6 @@ storage:
       user:
         name: root
       contents:
-        compression: null
         inline: |
           # This file controls the state of SELinux on the system.
           # SELINUX= can take one of these three values:
@@ -116,7 +110,6 @@ storage:
       group:
         name: root
       contents:
-        compression: null
         inline: |
           #!/bin/bash
           

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/user_data.json
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/user_data.json
@@ -1,14 +1,6 @@
 {
   "ignition": {
-    "version": "3.3.0"
-  },
-  "kernelArguments": {
-    "shouldExist": [
-      "mitigations=off"
-    ],
-    "shouldNotExist": [
-      "mitigations=auto,nosmt"
-    ]
+    "version": "3.0.0"
   },
   "passwd": {
     "users": [

--- a/releasenotes/notes/fedora-coreos-34-cb0d281d819e2523.yaml
+++ b/releasenotes/notes/fedora-coreos-34-cb0d281d819e2523.yaml
@@ -1,4 +1,0 @@
----
-upgrade:
-  - |
-    Minimum version of Fedora CoreOS required now is 34.


### PR DESCRIPTION
Revert reason: extension of existing clusters using Fedora CoreOS lower than 35 is broken.