### PR TITLE
coredns: Use /run/systemd/resolve/resolv.conf

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
@@ -84,7 +84,7 @@ data:
            fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . /etc/resolv.conf
+        forward . /run/systemd/resolve/resolv.conf
         cache 30
         loop
         reload
@@ -144,6 +144,9 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
+        - name: resolvconf
+          mountPath: /run/systemd/resolve/resolv.conf
+          readOnly: true
         ports:
         - containerPort: 53
           name: dns
@@ -186,6 +189,10 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+        - name: resolvconf
+          hostPath:
+            path: /run/systemd/resolve/resolv.conf
+            type: File
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
In FCOS36 and later coredns started failing with loops. /etc/resolv.conf will not work with coredns (see [1]).

Tested on FC35/36/37.

[1]: https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting

Change-Id: I3a0700046bade7bd0b3a1b319f66b8f675f0c8fb (cherry picked from commit 037a71aaf8664a7f6a8926dceb294592d73da591)