### PR TITLE
Revert "Merge pull request #93 from stackhpc/yoga_fcos_coreos"

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/core-dns-service.sh
@@ -84,7 +84,7 @@ data:
            fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . /run/systemd/resolve/resolv.conf
+        forward . /etc/resolv.conf
         cache 30
         loop
         reload
@@ -144,9 +144,6 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
-        - name: resolvconf
-          mountPath: /run/systemd/resolve/resolv.conf
-          readOnly: true
         ports:
         - containerPort: 53
           name: dns
@@ -189,10 +186,6 @@ spec:
             items:
             - key: Corefile
               path: Corefile
-        - name: resolvconf
-          hostPath:
-            path: /run/systemd/resolve/resolv.conf
-            type: File
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This reverts commit dad5b47ce1544cf916a984c76f51ab62e27c8c62, reversing changes made to e2cc3983e930e070fe81274a6dbf564758839cd7.

Revert reason: Moving to a different solution changing resolv.conf location for kubelet, which will work for all containers.