### PR TITLE
cinder-csi: disable host networking for controller

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-cinder-csi.sh
@@ -222,7 +222,6 @@ spec:
         app: csi-cinder-controllerplugin
     spec:
       serviceAccount: csi-cinder-controller-sa
-      hostNetwork: true
       tolerations:
         # Make sure the pod can be scheduled on master kubelet.
         - effect: NoSchedule


### PR DESCRIPTION
Adapt the manifest as per upstream template, currently the config doesn't allow nodeplugin to be run on the same host as controllerplugin.