### PR TITLE
Wallaby: Type and size labels for master and worker nodes

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -3155,6 +3155,39 @@ be used if none of those options is set. In case of master_volume_size or
 worker_volume_size missing value for boot_volume_size is used. If neither
 is defined instances will not be volume based.
 
+Labels can be used to customize nodes boot volume at creation time:
+
+- boot_volume_type
+- boot_volume_size
+
+These define volume type and size used for boot media of node vm, and they can
+be further overriden by:
+
+- master_volume_type
+- master_volume_size
+- worker_volume_type
+- worker_volume_size
+
+Current precedence is:
+- master_volume_size / worker_volume_size
+- boot_volume_size
+- default_boot_volume_size
+
+Labels shown above allow user to use different storage types and sizes for
+master and worker nodes. They can be used independently of each other
+for ex. boot_volume_type to define type of storage to use for both master
+and worker vms, along with master_volume_size and worker_volume_size
+setting size of their boot volumes. Another example would be usage of
+boot_volume_size to define size of both master and worker, with different
+storage types for them set by master_volume_type and worker_volume_type.
+It's possible to use any combination of the above.
+
+If either master_volume_type or worker_volume_type is missing,
+boot_volume_type will be used instead. A random volume type from Cinder will
+be used if none of those options is set. In case of master_volume_size or
+worker_volume_size missing value for boot_volume_size is used. If neither
+is defined instances will not be volume based.
+
 Following are some examples for using Cinder as persistent storage.
 
 Using Cinder in Kubernetes

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -255,6 +255,7 @@ parameters:
     type: string
     description: >
       type of the master cinder boot volume
+    default: ""
 
   worker_volume_size:
     type: number
@@ -265,6 +266,7 @@ parameters:
     type: string
     description: >
       type of the minion cinder boot volume
+    default: ""
 
   etcd_volume_size:
     type: number

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubeminion.yaml
@@ -55,6 +55,7 @@ parameters:
     type: string
     description: >
       type of the minion cinder boot volume
+    default: ""
 
   docker_volume_size:
     type: number


### PR DESCRIPTION
This change allows specifying different volume sizes and types for master and worker nodes. Volume types can be specified independent of size setting - falling back to boot_volume_size if specific node volume size label is not declared.

New labels added:
 - master_volume_size
 - master_volume_type
 - worker_volume_size
 - worker_volume_type

Change-Id: I02c6ec6944cf9d1e3c4cdc589785c05d84421a65 (cherry picked from commit 98f107934bee0ebc80e58ff8051833a5a52afcc8)