### PR TITLE
Missing load balancer health monitors fix

### DIFF
--- a/magnum/drivers/common/templates/lb_api.yaml
+++ b/magnum/drivers/common/templates/lb_api.yaml
@@ -13,7 +13,7 @@ conditions:
   octavia_lb_healthcheck_enabled:
       equals:
       - get_param: octavia_lb_healthcheck
-      - []
+      - True
 
 parameters:
 

--- a/magnum/drivers/common/templates/lb_etcd.yaml
+++ b/magnum/drivers/common/templates/lb_etcd.yaml
@@ -14,7 +14,7 @@ conditions:
   octavia_lb_healthcheck_enabled:
       equals:
       - get_param: octavia_lb_healthcheck
-      - []
+      - True
 
 parameters:
 


### PR DESCRIPTION
In api and etcd load balancer templates we define if Octavia load balancer healthchecks should be enabled. Corrected octavia_lb_healthcheck parameter value comparison.

Closes-bug: #2015393
Change-Id: Icee8be92ea3e3121934645049b81b79be9bd046a (cherry picked from commit f2dc76823c012c4e96ae0f9651c0c4e5596e62fd)