### PR TITLE
Support k8s 1.25 in Calico Manifest

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/calico-service.sh
@@ -4441,7 +4441,7 @@ metadata:
 
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: calico-kube-controllers


### PR DESCRIPTION
PodDisruptionBudget is `policy/v1` since 1.21.

https://github.com/projectcalico/calico/issues/4570

Change-Id: I07786095a30ae15fe856fd3966fc073267d2ae9d