### PR TITLE
Calico deployment with Tigera Operator

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -47,7 +47,61 @@
     post-run: playbooks/container-publish.yaml
     secrets:
       - magnum_docker_login
-    timeout: 2400
+    timeout: 7200
+
+- job:
+    name: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27
+    parent: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1
+    vars:
+      devstack_localrc:
+        MAGNUM_KUBECTL_TAG: v1.27.8
+      devstack_local_conf:
+        test-config:
+          $TEMPEST_CONFIG:
+            magnum:
+              labels:
+                kube_tag: v1.27.8-rancher2
+                container_runtime: containerd
+                containerd_version: 1.6.28
+                containerd_tarball_sha256: f70736e52d61e5ad225f4fd21643b5ca1220013ab8b6c380434caeefb572da9b
+                cloud_provider_tag: v1.27.3
+                cinder_csi_plugin_tag: v1.27.3
+                k8s_keystone_auth_tag: v1.27.3
+                magnum_auto_healer_tag: v1.27.3
+                octavia_ingress_controller_tag: v1.27.3
+
+- job:
+    name: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27-calico
+    parent: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27
+    vars:
+      devstack_local_conf:
+        test-config:
+          $TEMPEST_CONFIG:
+            magnum:
+              network_driver: calico
+
+- job:
+    name: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27-calico-helm
+    parent: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27
+    vars:
+      devstack_local_conf:
+        test-config:
+          $TEMPEST_CONFIG:
+            magnum:
+              network_driver: calico
+              labels:
+                calico_helm: true
+
+
+- job:
+    name: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27-flannel
+    parent: magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27
+    vars:
+      devstack_local_conf:
+        test-config:
+          $TEMPEST_CONFIG:
+            magnum:
+              network_driver: flannel
 
 - project:
     queue: magnum
@@ -60,6 +114,9 @@
     check:
       jobs:
         - magnum-tempest-plugin-tests-api
+        - magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27-flannel
+        - magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27-calico
+        - magnum-tempest-plugin-tests-cluster-k8s_fcos_v1-1.27-calico-helm
         - magnum-container-build
     gate:
       jobs:

--- a/magnum/drivers/common/templates/kubernetes/helm/calico-service.sh
+++ b/magnum/drivers/common/templates/kubernetes/helm/calico-service.sh
@@ -1,0 +1,57 @@
+set +x
+. /etc/sysconfig/heat-params
+set -ex
+
+CHART_NAME="tigera-operator"
+
+if [ "$NETWORK_DRIVER" = "calico" ]; then
+    #NOTE(mnasiadka): Split infra_prefix to registry and imagePath as per https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation
+    _prefix=${CONTAINER_INFRA_PREFIX:-quay.io/}
+    if [[ "${_prefix}" =~ .+/.+ ]]; then
+        REGISTRY=${_prefix%%/*}/
+        IMAGEPATH=${_prefix#*/}
+        IMAGEPATH=${IMAGEPATH%/*}
+    else
+        REGISTRY=${_prefix}
+    fi
+    echo "Writing ${CHART_NAME} config"
+    HELM_CHART_DIR="/srv/magnum/kubernetes/helm/calico"
+    mkdir -p ${HELM_CHART_DIR}
+    cat << EOF >> ${HELM_CHART_DIR}/values.yaml
+installation:
+  flexVolumePath: /opt/kubernetes/kubelet-plugins/volume/exec/
+  calicoNetwork:
+    ipPools:
+    - blockSize: 26
+      cidr: ${CALICO_IPV4POOL}
+      encapsulation: IPIP
+    nodeAddressAutodetectionV4:
+      cidrs:
+        - '${CLUSTER_SUBNET_CIDR}'
+  registry: ${REGISTRY}
+  imagePath: ${IMAGEPATH}
+  imagePrefix: "calico-"
+flexVolumePluginDir: /var/lib/kubelet/volumeplugins
+EOF
+    echo "Waiting for Kubernetes API..."
+    until  [ "ok" = "$(kubectl get --raw='/healthz')" ]; do
+        sleep 5
+    done
+    kubectl create namespace ${CHART_NAME}
+
+    helm_prepare_cmd="helm repo add projectcalico https://docs.tigera.io/calico/charts"
+    helm_install_cmd="helm upgrade --install calico projectcalico/tigera-operator --version ${CALICO_TAG} -f values.yaml --namespace tigera-operator"
+    helm_history_cmd="helm history calico --namespace tigera-operator"
+
+    if [[ -d "${HELM_CHART_DIR}" ]]; then
+        pushd ${HELM_CHART_DIR}
+        $helm_prepare_cmd
+        i=0
+        until ($helm_history_cmd | grep calico | grep deployed) || $helm_install_cmd; do
+            i=$((i + 1))
+            [ $i -lt 60 ] || break;
+            sleep 5
+        done
+        popd
+    fi
+fi

--- a/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_coreos_v1/templates/kubecluster.yaml
@@ -1062,6 +1062,13 @@ parameters:
       tag of the k8s.gcr.io/sig-storage/liveness-probe container
     default: v2.5.0
 
+  calico_helm:
+    type: boolean
+    description: >
+      If true, use Helm for Calico deployment otherwise, use
+      static Calico manifest' to the end of description
+    default: false
+
 resources:
 
   ######################################################################
@@ -1132,6 +1139,10 @@ resources:
         - protocol: tcp
           port_range_min: 179
           port_range_max: 179
+          # Calico - Typha
+        - protocol: tcp
+          port_range_min: 5473
+          port_range_max: 5473
         - protocol: tcp
           port_range_min: 7080
           port_range_max: 7080
@@ -1488,10 +1499,16 @@ resources:
             - "source /etc/bashrc"
             - get_file: ../../common/templates/kubernetes/fragments/kube-apiserver-to-kubelet-role.sh
             - get_file: ../../common/templates/kubernetes/fragments/core-dns-service.sh
+            - get_file: ../../common/templates/kubernetes/fragments/install-helm.sh
             - if:
-                - calico_v3_26
-                - get_file: ../../common/templates/kubernetes/fragments/calico-service-v3-26-x.sh
-                - get_file: ../../common/templates/kubernetes/fragments/calico-service-v3-21-x.sh
+                - equals:
+                  - get_param: calico_helm
+                  - false
+                - if:
+                  - calico_v3_26
+                  - get_file: ../../common/templates/kubernetes/fragments/calico-service-v3-26-x.sh
+                  - get_file: ../../common/templates/kubernetes/fragments/calico-service-v3-21-x.sh
+                - get_file: ../../common/templates/kubernetes/helm/calico-service.sh
             - get_file: ../../common/templates/kubernetes/fragments/flannel-service.sh
             - get_file: ../../common/templates/kubernetes/fragments/enable-helm-tiller.sh
             - str_replace:
@@ -1512,7 +1529,6 @@ resources:
             - get_file: ../../common/templates/kubernetes/fragments/enable-auto-scaling.sh
             - get_file: ../../common/templates/kubernetes/fragments/enable-cinder-csi.sh
             # Helm Based Installation Configuration Scripts
-            - get_file: ../../common/templates/kubernetes/fragments/install-helm.sh
             - get_file: ../../common/templates/kubernetes/helm/metrics-server.sh
             - str_replace:
                 template: {get_file: ../../common/templates/kubernetes/helm/prometheus-operator.sh}


### PR DESCRIPTION
Switched Calico installation to Helm charts - Tigera Operator. Added necessary port opening.

Depends-On: https://review.opendev.org/c/openstack/magnum-tempest-plugin/+/909444

Change-Id: I9e0cba930b70643bf19595f7cb544bc982ca027a