### PR TITLE
certs: add subject key identifier extension

### DIFF
--- a/magnum/common/x509/operations.py
+++ b/magnum/common/x509/operations.py
@@ -223,6 +223,12 @@ def sign(csr, issuer_name, ca_key, ca_key_password=None,
         builder = builder.add_extension(extention.value,
                                         critical=extention.critical)
 
+    subject_key_identifier = x509.SubjectKeyIdentifier.from_public_key(
+        csr.public_key())
+    builder = builder.add_extension(
+            subject_key_identifier, critical=False
+    )
+
     certificate = builder.sign(
         private_key=ca_key, algorithm=hashes.SHA256(),
     ).public_bytes(serialization.Encoding.PEM).strip()

--- a/releasenotes/notes/add-subject-key-identifer-ae5c6ebe86749239.yaml
+++ b/releasenotes/notes/add-subject-key-identifer-ae5c6ebe86749239.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add subject key identifier extension to x509 operations
+    signing function. Allows for magnum Kubernetes clusters
+    to generate certificates with authority key
+    identifier extension.


### PR DESCRIPTION
Add the subject key identifier extension to the certificate generated by Magnum. Which should permit Kubernetes clusters to have certificates that include authority key identifier extension which appears to be a requirement in Python 3.13 and newer.

Closes-Bug: #2097094
Change-Id: I13bbb97c8b17fbba2f5f1acfac9d597f12925818